### PR TITLE
Fixed issues with MATCH and INDEX functions

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
@@ -1,4 +1,28 @@
-﻿using OfficeOpenXml.FormulaParsing.Exceptions;
+﻿/* Copyright (C) 2011  Jan Källman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied. 
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author							Change						Date
+ *******************************************************************************
+ * Mats Alm   		                Added		                2013-12-03
+ *******************************************************************************/
+using OfficeOpenXml.FormulaParsing.Exceptions;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 using System;
 using System.Collections.Generic;
@@ -10,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
     {
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
-            if (ValidateArguments(arguments, 2) == false)
+            if (this.ValidateArguments(arguments, 2) == false)
             	return new CompileResult(eErrorType.Value);
             var arg1 = arguments.ElementAt(0);
             var arg2 = arguments.ElementAt(1);
@@ -18,7 +42,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             var crf = new CompileResultFactory();
             if (args != null)
             {
-                var index = ArgToInt(arguments, 1);
+                var index = this.ArgToInt(arguments, 1);
                 if (index > args.Count())
                     throw new ExcelErrorValueException(eErrorType.Ref);
                 var candidate = args.ElementAt(index - 1);
@@ -28,12 +52,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
                 return crf.Create(arg2.Value);
             if (arg1.IsExcelRange)
             {
-                var row = ArgToInt(arguments, 1);                 
-                var col = arguments.Count() > 2 ? ArgToInt(arguments, 2) : 1;
-                var ri = arg1.ValueAsRangeInfo;
-                if (row > ri.Address._toRow - ri.Address._fromRow + 1 || col > ri.Address._toCol - ri.Address._fromCol + 1)
+                var row = this.ArgToInt(arguments, 1);                 
+                var column = arguments.Count() > 2 ? this.ArgToInt(arguments, 2) : 1;
+                var rangeInfo = arg1.ValueAsRangeInfo;
+                if (row > rangeInfo.Address._toRow - rangeInfo.Address._fromRow + 1 || column > rangeInfo.Address._toCol - rangeInfo.Address._fromCol + 1)
 					return new CompileResult(eErrorType.Value);
-                var candidate = ri.GetOffset(row-1, col-1);
+                var candidate = rangeInfo.GetOffset(row-1, column-1);
                 return crf.Create(candidate);
             }
             throw new NotImplementedException();

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Exceptions;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
-using OfficeOpenXml.Utils;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
@@ -12,31 +10,29 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
     {
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
-            if(ValidateArguments(arguments, 2) == false)
+            if (ValidateArguments(arguments, 2) == false)
             	return new CompileResult(eErrorType.Value);
             var arg1 = arguments.ElementAt(0);
+            var arg2 = arguments.ElementAt(1);
             var args = arg1.Value as IEnumerable<FunctionArgument>;
             var crf = new CompileResultFactory();
             if (args != null)
             {
                 var index = ArgToInt(arguments, 1);
                 if (index > args.Count())
-                {
                     throw new ExcelErrorValueException(eErrorType.Ref);
-                }
                 var candidate = args.ElementAt(index - 1);
                 return crf.Create(candidate.Value);
             }
+            if (arg2 != null && arg2.Value is ExcelErrorValue && arg2.Value.ToString() == ExcelErrorValue.Values.NA)
+                return crf.Create(arg2.Value);
             if (arg1.IsExcelRange)
             {
                 var row = ArgToInt(arguments, 1);                 
-                var col = arguments.Count()>2 ? ArgToInt(arguments, 2) : 1;
-                var ri=arg1.ValueAsRangeInfo;
-                if (row > ri.Address._toRow - ri.Address._fromRow + 1 ||
-                    col > ri.Address._toCol - ri.Address._fromCol + 1)
-                {
+                var col = arguments.Count() > 2 ? ArgToInt(arguments, 2) : 1;
+                var ri = arg1.ValueAsRangeInfo;
+                if (row > ri.Address._toRow - ri.Address._fromRow + 1 || col > ri.Address._toCol - ri.Address._fromCol + 1)
 					return new CompileResult(eErrorType.Value);
-                }
                 var candidate = ri.GetOffset(row-1, col-1);
                 return crf.Create(candidate);
             }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Index.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using OfficeOpenXml.FormulaParsing.Exceptions;
+using OfficeOpenXml.FormulaParsing.ExpressionGraph;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using OfficeOpenXml.FormulaParsing.Exceptions;
-using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -22,12 +22,10 @@
  *******************************************************************************
  * Mats Alm   		                Added		                2013-12-03
  *******************************************************************************/
-using System;
+using OfficeOpenXml.FormulaParsing.ExcelUtilities;
+using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using OfficeOpenXml.FormulaParsing.ExpressionGraph;
-using OfficeOpenXml.FormulaParsing.ExcelUtilities;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -42,23 +42,23 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
-            if (ValidateArguments(arguments, 2) == false)
+            if (this.ValidateArguments(arguments, 2) == false)
             	return new CompileResult(eErrorType.Value);
             var searchedValue = arguments.ElementAt(0).Value;
-            var address =  arguments.ElementAt(1).IsExcelRange ? arguments.ElementAt(1).ValueAsRangeInfo.Address.FullAddress : ArgToString(arguments, 1);
+            var address =  arguments.ElementAt(1).IsExcelRange ? arguments.ElementAt(1).ValueAsRangeInfo.Address.FullAddress : this.ArgToString(arguments, 1);
             var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
             var rangeAddress = rangeAddressFactory.Create(address);
-            var matchType = GetMatchType(arguments);
+            var matchType = this.GetMatchType(arguments);
             var args = new LookupArguments(searchedValue, address, 0, 0, false, arguments.ElementAt(1).ValueAsRangeInfo);
-            var lookupDirection = GetLookupDirection(rangeAddress);
+            var lookupDirection = this.GetLookupDirection(rangeAddress);
             var navigator = LookupNavigatorFactory.Create(lookupDirection, args, context);
             int? lastValidIndex = null;
             do
             {
-                var matchResult = IsMatch(navigator.CurrentValue, searchedValue);
+                var matchResult = this.IsMatch(navigator.CurrentValue, searchedValue);
                 // For all match types, if the match result indicated equality, return the index (1 based)
                 if (matchResult == 0)
-                    return CreateResult(navigator.Index + 1, DataType.Integer);
+                    return this.CreateResult(navigator.Index + 1, DataType.Integer);
                 if ((matchType == MatchType.ClosestBelow && matchResult < 0) || (matchType == MatchType.ClosestAbove && matchResult > 0))
                     lastValidIndex = navigator.Index + 1;
                 // If matchType is ClosestBelow or ClosestAbove and the match result test failed, no more searching is required
@@ -67,15 +67,15 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             }
             while (navigator.MoveNext());
             if (lastValidIndex == null)
-                return CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
-            return CreateResult(lastValidIndex, DataType.Integer);
+                return this.CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
+            return this.CreateResult(lastValidIndex, DataType.Integer);
         }
 
         private MatchType GetMatchType(IEnumerable<FunctionArgument> arguments)
         {
             var matchType = MatchType.ClosestBelow;
             if (arguments.Count() > 2)
-                matchType = (MatchType)ArgToInt(arguments, 2);
+                matchType = (MatchType)this.ArgToInt(arguments, 2);
             return matchType;
         }
     }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -40,17 +40,12 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             ClosestBelow = 1
         }
 
-        public Match()
-            : base(new WildCardValueMatcher(), new CompileResultFactory())
-        {
-
-        }
+        public Match() : base(new WildCardValueMatcher(), new CompileResultFactory()) { }
 
         public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
         {
-            if(ValidateArguments(arguments, 2) == false)
+            if (ValidateArguments(arguments, 2) == false)
             	return new CompileResult(eErrorType.Value);
-
             var searchedValue = arguments.ElementAt(0).Value;
             var address =  arguments.ElementAt(1).IsExcelRange ? arguments.ElementAt(1).ValueAsRangeInfo.Address.FullAddress : ArgToString(arguments, 1);
             var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
@@ -63,24 +58,18 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
             do
             {
                 var matchResult = IsMatch(navigator.CurrentValue, searchedValue);
-
                 // For all match types, if the match result indicated equality, return the index (1 based)
                 if (matchResult == 0)
-                {
                     return CreateResult(navigator.Index + 1, DataType.Integer);
-                }
-
                 if ((matchType == MatchType.ClosestBelow && matchResult < 0) || (matchType == MatchType.ClosestAbove && matchResult > 0))
-                {
                     lastValidIndex = navigator.Index + 1;
-                }
                 // If matchType is ClosestBelow or ClosestAbove and the match result test failed, no more searching is required
                 else if (matchType == MatchType.ClosestBelow || matchType == MatchType.ClosestAbove)
-                {
                     break;
-                }
             }
             while (navigator.MoveNext());
+            if (lastValidIndex == null)
+                return CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
             return CreateResult(lastValidIndex, DataType.Integer);
         }
 
@@ -88,9 +77,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
         {
             var matchType = MatchType.ClosestBelow;
             if (arguments.Count() > 2)
-            {
                 matchType = (MatchType)ArgToInt(arguments, 2);
-            }
             return matchType;
         }
     }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
@@ -36,16 +36,12 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class DefaultCompiler : FunctionCompiler
     {
-        public DefaultCompiler(ExcelFunction function)
-            : base(function)
-        {
-
-        }
+        public DefaultCompiler(ExcelFunction function) : base(function) { }
 
         public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
         {
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            this.Function.BeforeInvoke(context);
             foreach (var child in children)
             {
                 var compileResult = child.Compile();
@@ -57,10 +53,10 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 }
                 else
                 {
-                    BuildFunctionArguments(compileResult.Result, compileResult.DataType, args);     
+                    this.BuildFunctionArguments(compileResult.Result, compileResult.DataType, args);     
                 }
             }
-            return Function.Execute(args, context);
+            return this.Function.Execute(args, context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
@@ -28,10 +28,7 @@
  * ******************************************************************************
  * Mats Alm   		                Added       		        2013-03-01 (Prior file history on https://github.com/swmal/ExcelFormulaParser)
  *******************************************************************************/
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
 
@@ -60,7 +57,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 }
                 else
                 {
-                    BuildFunctionArguments(compileResult.Result, args);     
+                    BuildFunctionArguments(compileResult.Result, compileResult.DataType, args);     
                 }
             }
             return Function.Execute(args, context);

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/DefaultCompiler.cs
@@ -28,9 +28,9 @@
  * ******************************************************************************
  * Mats Alm   		                Added       		        2013-03-01 (Prior file history on https://github.com/swmal/ExcelFormulaParser)
  *******************************************************************************/
-using System.Collections.Generic;
 using OfficeOpenXml.FormulaParsing.Excel;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
+using System.Collections.Generic;
 
 namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
@@ -28,12 +28,9 @@
  * ******************************************************************************
  * Mats Alm   		                Added       		        2013-03-01 (Prior file history on https://github.com/swmal/ExcelFormulaParser)
  *******************************************************************************/
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
 using OfficeOpenXml.FormulaParsing.Exceptions;
+using System.Collections.Generic;
 
 namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
@@ -53,7 +53,10 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 try
                 {
                     var arg = child.Compile();
-                    BuildFunctionArguments(arg != null ? arg.Result : null, args);
+                    if (arg != null)
+                        BuildFunctionArguments(arg.Result, arg.DataType, args);
+                    else
+                        BuildFunctionArguments(null, DataType.Unknown, args);
                 }
                 catch (ExcelErrorValueException efe)
                 {

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ErrorHandlingFunctionCompiler.cs
@@ -30,42 +30,39 @@
  *******************************************************************************/
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
 using OfficeOpenXml.FormulaParsing.Exceptions;
+using System;
 using System.Collections.Generic;
 
 namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public class ErrorHandlingFunctionCompiler : FunctionCompiler
     {
-        public ErrorHandlingFunctionCompiler(ExcelFunction function)
-            : base(function)
-        {
-
-        }
+        public ErrorHandlingFunctionCompiler(ExcelFunction function) : base(function) { }
         public override CompileResult Compile(IEnumerable<Expression> children, ParsingContext context)
         {
             var args = new List<FunctionArgument>();
-            Function.BeforeInvoke(context);
+            this.Function.BeforeInvoke(context);
             foreach (var child in children)
             {
                 try
                 {
                     var arg = child.Compile();
                     if (arg != null)
-                        BuildFunctionArguments(arg.Result, arg.DataType, args);
+                        this.BuildFunctionArguments(arg.Result, arg.DataType, args);
                     else
-                        BuildFunctionArguments(null, DataType.Unknown, args);
+                        this.BuildFunctionArguments(null, DataType.Unknown, args);
                 }
-                catch (ExcelErrorValueException efe)
+                catch (ExcelErrorValueException ex)
                 {
-                    return ((ErrorHandlingFunction)Function).HandleError(efe.ErrorValue.ToString());
+                    return ((ErrorHandlingFunction)this.Function).HandleError(ex.ErrorValue.ToString());
                 }
-                catch// (Exception e)
+                catch (Exception)
                 {
-                    return ((ErrorHandlingFunction)Function).HandleError(ExcelErrorValue.Values.Value);
+                    return ((ErrorHandlingFunction)this.Function).HandleError(ExcelErrorValue.Values.Value);
                 }
                 
             }
-            return Function.Execute(args, context);
+            return this.Function.Execute(args, context);
         }
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
@@ -28,13 +28,9 @@
  * ******************************************************************************
  * Mats Alm   		                Added       		        2013-03-01 (Prior file history on https://github.com/swmal/ExcelFormulaParser)
  *******************************************************************************/
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
-using System.Collections;
 using OfficeOpenXml.FormulaParsing.Utilities;
+using System.Collections.Generic;
 
 namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
@@ -70,11 +70,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
             }
         }
 
-        protected void BuildFunctionArguments(object result, List<FunctionArgument> args)
-        {
-            BuildFunctionArguments(result, DataType.Unknown, args);
-        }
-
         public abstract CompileResult Compile(IEnumerable<Expression> children, ParsingContext context);
     }
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/FunctionCompiler.cs
@@ -36,16 +36,12 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 {
     public abstract class FunctionCompiler
     {
-        protected ExcelFunction Function
-        {
-            get;
-            private set;
-        }
+        protected ExcelFunction Function { get; private set; }
 
         public FunctionCompiler(ExcelFunction function)
         {
             Require.That(function).Named("function").IsNotNull();
-            Function = function;
+            this.Function = function;
         }
 
         protected void BuildFunctionArguments(object result, DataType dataType, List<FunctionArgument> args)
@@ -56,7 +52,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
                 var objects = result as IEnumerable<object>;
                 foreach (var arg in objects)
                 {
-                    BuildFunctionArguments(arg, dataType, argList);
+                    this.BuildFunctionArguments(arg, dataType, argList);
                 }
                 args.Add(new FunctionArgument(argList));
             }

--- a/EPPlusTest/EPPlusTest.csproj
+++ b/EPPlusTest/EPPlusTest.csproj
@@ -117,6 +117,7 @@
     <Compile Include="FormulaParsing\Excel\Functions\Math\CountIfTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Math\FloorTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Math\SumIfTests.cs" />
+    <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\MatchTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\SubtotalTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\SumIfsTests.cs" />
     <Compile Include="FormulaParsing\ExpressionGraph\CompileResultFactoryTests.cs" />

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
@@ -1,4 +1,28 @@
-﻿using EPPlusTest.FormulaParsing.TestHelpers;
+﻿/* Copyright (C) 2011  Jan Källman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied. 
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author							Change						Date
+ *******************************************************************************
+ * Mats Alm   		                Added		                2013-12-03
+ *******************************************************************************/
+using EPPlusTest.FormulaParsing.TestHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing;

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
@@ -1,9 +1,9 @@
-﻿using System.IO;
-using EPPlusTest.FormulaParsing.TestHelpers;
+﻿using EPPlusTest.FormulaParsing.TestHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+using System.IO;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/IndexTests.cs
@@ -1,73 +1,79 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using EPPlusTest.FormulaParsing.TestHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
-using OfficeOpenXml.FormulaParsing.Exceptions;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {
     [TestClass]
     public class IndexTests
     {
-        private ParsingContext _parsingContext;
-        private ExcelPackage _package;
-        private ExcelWorksheet _worksheet;
+        #region Properties
+        private ParsingContext ParsingContext { get; set; }
+        private ExcelPackage Package { get; set; }
+        private ExcelWorksheet Worksheet { get; set; }
+        #endregion
 
+        #region TestInitialize/TestCleanup
         [TestInitialize]
         public void Initialize()
         {
-            _parsingContext = ParsingContext.Create();
-            _package = new ExcelPackage(new MemoryStream());
-            _worksheet = _package.Workbook.Worksheets.Add("test");
+            this.ParsingContext = ParsingContext.Create();
+            this.Package = new ExcelPackage(new MemoryStream());
+            this.Worksheet = this.Package.Workbook.Worksheets.Add("test");
         }
 
         [TestCleanup]
         public void Cleanup()
         {
-            _package.Dispose();
+            this.Package.Dispose();
         }
+        #endregion
 
-		[TestMethod]
+        #region Index Tests
+        [TestMethod]
 		public void IndexReturnsPoundValueWhenTooFewArgumentsAreSupplied()
 		{
-			_worksheet.Cells["A1"].Value = 1d;
-			_worksheet.Cells["A2"].Value = 3d;
-			_worksheet.Cells["A3"].Value = 5d;
-
-			_worksheet.Cells["A4"].Formula = "INDEX(A1:A3,213)";
-
-			_worksheet.Calculate();
-
-			Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), _worksheet.Cells["A4"].Value);
+			this.Worksheet.Cells["A1"].Value = 1d;
+			this.Worksheet.Cells["A2"].Value = 3d;
+			this.Worksheet.Cells["A3"].Value = 5d;
+			this.Worksheet.Cells["A4"].Formula = "INDEX(A1:A3,213)";
+			this.Worksheet.Calculate();
+			Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), this.Worksheet.Cells["A4"].Value);
 		}
 
 		[TestMethod]
-        public void Index_Should_Return_Value_By_Index()
+        public void IndexReturnsValueByIndex()
         {
             var func = new Index();
-            var result = func.Execute(
-                FunctionsHelper.CreateArgs(
-                    FunctionsHelper.CreateArgs(1, 2, 5),
-                    3
-                    ),_parsingContext);
+            var result = func.Execute(FunctionsHelper.CreateArgs(FunctionsHelper.CreateArgs(1, 2, 5), 3), this.ParsingContext);
             Assert.AreEqual(5, result.Result);
         }
 
         [TestMethod]
-        public void Index_Should_Handle_SingleRange()
+        public void IndexHandlesSingleRange()
         {
-            _worksheet.Cells["A1"].Value = 1d;
-            _worksheet.Cells["A2"].Value = 3d;
-            _worksheet.Cells["A3"].Value = 5d;
-
-            _worksheet.Cells["A4"].Formula = "INDEX(A1:A3;3)";
-
-            _worksheet.Calculate();
-
-            Assert.AreEqual(5d, _worksheet.Cells["A4"].Value);
+            this.Worksheet.Cells["A1"].Value = 1d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "INDEX(A1:A3,3)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(5d, this.Worksheet.Cells["A4"].Value);
         }
-	}
+
+        [TestMethod]
+        public void IndexHandlesNAError()
+        {
+            this.Worksheet.Cells["A1"].Value = 1d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Value = ExcelErrorValue.Create(eErrorType.NA);
+            this.Worksheet.Cells["A5"].Formula = "INDEX(A1:A3,A4)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), this.Worksheet.Cells["A5"].Value);
+        }
+        #endregion
+    }
 }

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
@@ -1,0 +1,188 @@
+﻿using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
+{
+    [TestClass]
+    public class MatchTests
+    {
+        #region Properties
+        private ExcelPackage Package { get; set; }
+        private ExcelWorksheet Worksheet { get; set; }
+        #endregion
+
+        #region TestInitialize/TestCleanup
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.Package = new ExcelPackage(new MemoryStream());
+            this.Worksheet = this.Package.Workbook.Worksheets.Add("test");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.Package.Dispose();
+        }
+
+        [TestMethod]
+        public void MatchInvalidParameterCount()
+        {
+            this.Worksheet.Cells["A4"].Formula = "MATCH(3)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), this.Worksheet.Cells["A4"].Value);
+        }
+        #endregion
+
+        #region Match Tests
+        [TestMethod]
+        public void MatchExact()
+        {
+            this.Worksheet.Cells["A1"].Value = 5d;
+            this.Worksheet.Cells["A2"].Value = 1d;
+            this.Worksheet.Cells["A3"].Value = 3d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(3,A1:A3,0)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(3, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchExactNotFound()
+        {
+            this.Worksheet.Cells["A1"].Value = 5d;
+            this.Worksheet.Cells["A2"].Value = 1d;
+            this.Worksheet.Cells["A3"].Value = 3d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(2,A1:A3,0)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchLessThanExact()
+        {
+            // Match for "less than" requires values be in acending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value greater than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 1d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(3,A1:A3,1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(2, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchLessThanNotExact()
+        {
+            // Match for "less than" requires values be in acending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value greater than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 1d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(4,A1:A3,1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(2, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchLessThanNotFound()
+        {
+            // Match for "less than" requires values be in acending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value greater than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 2d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(1,A1:A3,1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchLessThanNotAcending()
+        {
+            // NOTE: this is not how MATCH is intended to be used, but how Excel behaves.
+
+            // Match for "less than" requires values be in acending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value greater than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 1d;
+            this.Worksheet.Cells["A2"].Value = 7d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(6,A1:A3,1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(1, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchGreaterThanExact()
+        {
+            // Match for "greater than" requires values be in descending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value less than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 5d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 1d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(3,A1:A3,-1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(2, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchGreaterThanNotExact()
+        {
+            // Match for "greater than" requires values be in descending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value less than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 5d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 1d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(2,A1:A3,-1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(2, this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchGreaterThanNotFound()
+        {
+            // Match for "greater than" requires values be in descending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value less than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 5d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 1d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(6,A1:A3,-1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(ExcelErrorValue.Create(eErrorType.NA), this.Worksheet.Cells["A4"].Value);
+        }
+
+        [TestMethod]
+        public void MatchGreaterThanNotDescending()
+        {
+            // NOTE: this is not how MATCH is intended to be used, 
+            // but how Excel behaves in this case.
+
+            // Match for "greater than" requires values be in descending order, 
+            // in order to find the closest value to the search value.
+            // Otherwise, the index of the value immediately preceding 
+            // the first value less than the search value will be found.
+            this.Worksheet.Cells["A1"].Value = 7d;
+            this.Worksheet.Cells["A2"].Value = 3d;
+            this.Worksheet.Cells["A3"].Value = 5d;
+            this.Worksheet.Cells["A4"].Formula = "MATCH(4,A1:A3,-1)";
+            this.Worksheet.Calculate();
+            Assert.AreEqual(1, this.Worksheet.Cells["A4"].Value);
+        }
+        #endregion
+    }
+}

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
@@ -1,4 +1,28 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿/* Copyright (C) 2011  Jan Källman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The GNU Lesser General Public License can be viewed at http://www.opensource.org/licenses/lgpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ *
+ * All code and executables are provided "as is" with no warranty either express or implied. 
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ * Code change notes:
+ * 
+ * Author							Change						Date
+ *******************************************************************************
+ * Max Ackley		                Added		                2017-05-05
+ *******************************************************************************/
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using System.IO;
 

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/MatchTests.cs
@@ -1,7 +1,6 @@
-﻿using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
-using OfficeOpenXml.FormulaParsing;
+using System.IO;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {


### PR DESCRIPTION
Fixed issue where MATCH function would not return #N/A if no value was found.
Fixed issue where INDEX function would not return #N/A if row/column parameter was also #N/A.
Fixed issue where DefaultCompiler would not populate datatypes of arguments.