### PR TITLE
Added ZipPackage.TryGetPart() method.

### DIFF
--- a/EPPlus/ExcelWorksheets.cs
+++ b/EPPlus/ExcelWorksheets.cs
@@ -1237,10 +1237,9 @@ namespace OfficeOpenXml
 			for (int i = 0; i < rels.Count; i++)
 			{
 				var rel = rels[i];
-				if (rel.RelationshipType != ExcelPackage.schemaImage)
-				{
-					this.DeleteRelationsAndParts(this.Package.Package.GetPart(UriHelper.ResolvePartUri(rel.SourceUri, rel.TargetUri)));
-				}
+				if (rel.RelationshipType != ExcelPackage.schemaImage &&
+						this.Package.Package.TryGetPart(UriHelper.ResolvePartUri(rel.SourceUri, rel.TargetUri), out Packaging.ZipPackagePart relPart))
+					this.DeleteRelationsAndParts(relPart);
 				part.DeleteRelationship(rel.Id);
 			}
 			this.Package.Package.DeletePart(part.Uri);

--- a/EPPlus/Packaging/ZipPackage.cs
+++ b/EPPlus/Packaging/ZipPackage.cs
@@ -202,18 +202,30 @@ namespace OfficeOpenXml.Packaging
 			Parts.Add(GetUriKey(part.Uri.OriginalString), part);
 			return part;
 		}
+		/// <summary>
+		/// Gets the part with the specified <paramref name="partUri"/>.
+		/// </summary>
+		/// <param name="partUri">The URI of the part to get.</param>
+		/// <returns>The part with the specified <paramref name="partUri"/>.</returns>
+		/// <exception cref="InvalidOperationException">Thrown when a part with the specified <paramref name="partUri"/> does not exist.</exception>
 		internal ZipPackagePart GetPart(Uri partUri)
 		{
-			if (PartExists(partUri))
-			{
-				return Parts.Single(x => x.Key.Equals(GetUriKey(partUri.OriginalString), StringComparison.InvariantCultureIgnoreCase)).Value;
-			}
-			else
-			{
-				throw (new InvalidOperationException("Part does not exist."));
-			}
+			if (this.TryGetPart(partUri, out ZipPackagePart part))
+				return part;
+			throw (new InvalidOperationException("Part does not exist."));
 		}
-
+		/// <summary>
+		/// Tries to get the part with the specified <paramref name="partUri"/>.
+		/// </summary>
+		/// <param name="partUri">The URI of the part to get.</param>
+		/// <param name="part">The part with the specified <paramref name="partUri"/> if it exists; otherwise, null.</param>
+		/// <returns>true if a part with the specified <paramref name="partUri"/> exists; otherwise, false.</returns>
+		internal bool TryGetPart(Uri partUri, out ZipPackagePart part)
+		{
+			var partExists = this.PartExists(partUri);
+			part = partExists ? Parts.Single(x => x.Key.Equals(GetUriKey(partUri.OriginalString), StringComparison.InvariantCultureIgnoreCase)).Value : null;
+			return partExists;
+		}
 		internal string GetUriKey(string uri)
 		{
 			string ret = uri;

--- a/EPPlusTest/ExcelWorksheetTests.cs
+++ b/EPPlusTest/ExcelWorksheetTests.cs
@@ -2508,6 +2508,23 @@ namespace EPPlusTest
 			}
 		}
 
+		[TestMethod]
+		public void DeleteWorksheetWithImageWithHyperlink()
+		{
+			using (ExcelPackage package = new ExcelPackage())
+			{
+				var ws1 = package.Workbook.Worksheets.Add("sheet1");
+				var ws2 = package.Workbook.Worksheets.Add("sheet2");
+				Bitmap image = new Bitmap(2, 2);
+				image.SetPixel(1, 1, Color.Black);
+				ws1.Drawings.AddPicture("Test", image, new Uri("http://wwww.jetreports.com"));
+				package.Save();
+				Assert.AreEqual(2, package.Workbook.Worksheets.Count);
+				package.Workbook.Worksheets.Delete(ws1);
+				Assert.AreEqual(1, package.Workbook.Worksheets.Count);
+			}
+		}
+
 		[TestMethod, Ignore]
 		public void Issue15207()
 		{


### PR DESCRIPTION
Fixed issue where deleting a worksheet with an image with a hyperlink caused an InvalidOperationException with a "Part does not exist." message.