### PR TITLE
Fix an issue where deleting rows would yield incorrect data.

### DIFF
--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -764,6 +764,7 @@ internal class CellStore<T> : ICellStore<T>, IDisposable// : IEnumerable<ulong>,
 				var pageFromRow = fromRow >> pageBits;
 				for (int c = 0; c < this.ColumnCount; c++)
 				{
+					int rowsToDelete = rows;
 					var column = this._columnIndex[c];
 					if (column.Index >= fromCol)
 					{
@@ -774,25 +775,27 @@ internal class CellStore<T> : ICellStore<T>, IDisposable// : IEnumerable<ulong>,
 						if (pagePos < column.PageCount)
 						{
 							var page = column._pages[pagePos];
-							if (shift && page.RowCount > 0 && page.MinIndex > fromRow && page.MaxIndex >= fromRow + rows)
+							if (shift && page.RowCount > 0 && page.MinIndex > fromRow && page.MaxIndex >= fromRow + rowsToDelete)
 							{
+								// The entire page is being shifted.
 								var o = page.MinIndex - fromRow;
-								if (o < rows)
+								if (o < rowsToDelete)
 								{
-									rows -= o;
+									rowsToDelete -= o;
 									page.Offset -= o;
 									this.UpdatePageOffset(column, pagePos, o);
 								}
 								else
 								{
-									page.Offset -= rows;
-									this.UpdatePageOffset(column, pagePos, rows);
+									page.Offset -= rowsToDelete;
+									this.UpdatePageOffset(column, pagePos, rowsToDelete);
 									continue;
 								}
 							}
-							if (page.RowCount > 0 && page.MinIndex <= fromRow + rows - 1 && page.MaxIndex >= fromRow) //The row is inside the page
+							if (page.RowCount > 0 && page.MinIndex <= fromRow + rowsToDelete - 1 && page.MaxIndex >= fromRow) 
 							{
-								var endRow = fromRow + rows;
+								// The range starts within a page: shift rows within the page. 
+								var endRow = fromRow + rowsToDelete;
 								var delEndRow = this.DeleteCells(column._pages[pagePos], fromRow, endRow, shift);
 								if (shift && delEndRow != fromRow)
 									this.UpdatePageOffset(column, pagePos, delEndRow - fromRow);
@@ -813,18 +816,18 @@ internal class CellStore<T> : ICellStore<T>, IDisposable// : IEnumerable<ulong>,
 							}
 							else if (pagePos > 0 && column._pages[pagePos].IndexOffset > fromRow) //The row is on the page before.
 							{
-								int offset = fromRow + rows - 1 - ((pageFromRow - 1) << pageBits);
+								int offset = fromRow + rowsToDelete - 1 - ((pageFromRow - 1) << pageBits);
 								var rowPos = column._pages[pagePos - 1].GetPosition(offset);
 								if (rowPos > 0 && pagePos > 0)
 								{
 									if (shift)
-										this.UpdateIndexOffset(column, pagePos - 1, rowPos, fromRow + rows - 1, -rows);
+										this.UpdateIndexOffset(column, pagePos - 1, rowPos, fromRow + rowsToDelete - 1, -rowsToDelete);
 								}
 							}
 							else
 							{
 								if (shift && pagePos + 1 < column.PageCount)
-									this.UpdateIndexOffset(column, pagePos + 1, 0, column._pages[pagePos + 1].MinIndex, -rows);
+									this.UpdateIndexOffset(column, pagePos + 1, 0, column._pages[pagePos + 1].MinIndex, -rowsToDelete);
 							}
 						}
 					}

--- a/EPPlus/CellStore.cs
+++ b/EPPlus/CellStore.cs
@@ -808,6 +808,11 @@ internal class CellStore<T> : ICellStore<T>, IDisposable// : IEnumerable<ulong>,
 									{
 										var fr = shift ? fromRow : endRow - rowsLeft;
 										pagePos = column.GetPosition(fr);
+										// This should never be the same page we deleted from earlier in this method.
+										// Rather, it should be the next [remaining] page.
+										// The only valid same-index case is when the entire original page was deleted. 
+										if (page == column._pages[pagePos] && column._pages[pagePos + 1] != null)
+											pagePos++;
 										delEndRow = this.DeleteCells(column._pages[pagePos], fr, shift ? fr + rowsLeft : endRow, shift);
 										if (shift)
 											this.UpdatePageOffset(column, pagePos, rowsLeft);
@@ -1313,6 +1318,8 @@ internal class CellStore<T> : ICellStore<T>, IDisposable// : IEnumerable<ulong>,
 
 	private int DeleteCells(PageIndex page, int fromRow, int toRow, bool shift)
 	{
+		if (page.RowCount == 0)
+			return fromRow;
 		var fromPos = page.GetPosition(fromRow - (page.IndexOffset));
 		if (fromPos < 0)
 		{

--- a/EPPlusTest/CellStoreTest.cs
+++ b/EPPlusTest/CellStoreTest.cs
@@ -100,6 +100,34 @@ namespace EPPlusTest
 		}
 
 		[TestMethod]
+		public void DeleteRowsAcrossMultipleCellStorePages()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet = package.Workbook.Worksheets.Add("Sheet");
+				for (int i = 1; i < 1024; i++)
+				{
+					sheet.Cells[i, 2].Value = i;
+				}
+				for (int i = 1500; i < 4096; i++)
+				{
+					sheet.Cells[i, 2].Value = i;
+				}
+				int splitPoint = 400;
+				sheet.DeleteRow(splitPoint, 600);
+				sheet.DeleteRow(splitPoint, 600);
+				for (int i = 1; i < splitPoint; i++)
+				{
+					Assert.AreEqual(i, sheet.Cells[i, 2].Value);
+				}
+				for (int i = splitPoint; i < 2872; i++)
+				{
+					Assert.AreEqual(i + 1200, sheet.Cells[i, 2].Value);
+				}
+			}
+		}
+
+		[TestMethod]
 		public void Insert1()
 		{
 			var ws = _pck.Workbook.Worksheets.Add("Insert1");

--- a/EPPlusTest/CellStoreTest.cs
+++ b/EPPlusTest/CellStoreTest.cs
@@ -75,6 +75,31 @@ namespace EPPlusTest
 		}
 
 		[TestMethod]
+		public void DeleteRowsHandlesDifferentShapesOfColumns()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet = package.Workbook.Worksheets.Add("Sheet");
+				for (int row = 4; row <= 8; row++)
+				{
+					sheet.Cells[row, 2].Formula = $"{row}";
+				}
+				for (int row = 1; row <= 8; row++)
+				{
+					sheet.Cells[row, 3].Formula = $"{row}";
+				}
+				sheet.DeleteRow(2, 4);
+				Assert.AreEqual("1", sheet.Cells[1, 3].Formula);
+				Assert.AreEqual("6", sheet.Cells[2, 2].Formula);
+				Assert.AreEqual("6", sheet.Cells[2, 3].Formula);
+				Assert.AreEqual("7", sheet.Cells[3, 2].Formula);
+				Assert.AreEqual("7", sheet.Cells[3, 3].Formula);
+				Assert.AreEqual("8", sheet.Cells[4, 2].Formula);
+				Assert.AreEqual("8", sheet.Cells[4, 3].Formula);
+			}
+		}
+
+		[TestMethod]
 		public void Insert1()
 		{
 			var ws = _pck.Workbook.Worksheets.Add("Insert1");


### PR DESCRIPTION
 (not deleting enough rows) when the relevant page for the first column started after the row where deletion was occurring, but a subsequent column's page had data both before and after the row[s] being deleted.