### PR TITLE
Add null check before setting copied sparkline formulas.

### DIFF
--- a/EPPlus/Drawing/Sparkline/ExcelSparkline.cs
+++ b/EPPlus/Drawing/Sparkline/ExcelSparkline.cs
@@ -74,7 +74,6 @@ namespace OfficeOpenXml.Drawing.Sparkline
 			var hostNode = topNode.SelectSingleNode("xm:sqref", nameSpaceManager);
 			this.Formula = formulaNode != null ? new ExcelAddress(formulaNode.InnerText) : null;
 			this.HostCell = group.Worksheet.Cells[hostNode.InnerText];
-			group.Worksheet.Cells[this.HostCell.Address].Sparklines.Add(this);
 		}
 
 		/// <summary>
@@ -113,7 +112,6 @@ namespace OfficeOpenXml.Drawing.Sparkline
 			var hostNode = this.TopNode.OwnerDocument.CreateElement("xm:sqref", "http://schemas.microsoft.com/office/excel/2006/main");
 			hostNode.InnerText = this.HostCell.Address;
 			this.TopNode.AppendChild(hostNode);
-			this.Group.Worksheet.Cells[this.HostCell.Address].Sparklines.Add(this);
 		}
 		#endregion
 	}

--- a/EPPlus/ExcelRangeBase.cs
+++ b/EPPlus/ExcelRangeBase.cs
@@ -750,8 +750,6 @@ namespace OfficeOpenXml
 				return fullAddress.TrimEnd(',');
 			}
 		}
-
-		internal List<ExcelSparkline> Sparklines { get; } = new List<ExcelSparkline>();
 		#endregion
 
 		#region Private Methods
@@ -1323,15 +1321,18 @@ namespace OfficeOpenXml
 				{
 					if (sparkline.HostCell.Collide(this) != eAddressCollition.No)
 					{
-						ExcelRangeBase.SplitAddress(sparkline.Formula.Address, out string workbook, out string worksheet, out string address);
-						string newFormulaString = this.myWorkbook.Package.FormulaManager.UpdateFormulaReferences(address, destination._fromRow - this._fromRow, destination._fromCol - this._fromCol, 0, 0, this.WorkSheet, this.WorkSheet, true);
 						ExcelAddress newFormula = null;
-						if (newFormulaString != "#REF!")
+						if (sparkline.Formula != null)
 						{
-							if (this.Worksheet.Name == worksheet)
-								worksheet = destination.Worksheet.Name;
-							newFormulaString = string.IsNullOrEmpty(worksheet) ? newFormulaString : ExcelRangeBase.GetFullAddress(worksheet, newFormulaString);
-							newFormula = new ExcelAddress(newFormulaString);
+							ExcelRangeBase.SplitAddress(sparkline.Formula.Address, out string workbook, out string worksheet, out string address);
+							string newFormulaString = this.myWorkbook.Package.FormulaManager.UpdateFormulaReferences(address, destination._fromRow - this._fromRow, destination._fromCol - this._fromCol, 0, 0, this.WorkSheet, this.WorkSheet, true);
+							if (newFormulaString != "#REF!")
+							{
+								if (this.Worksheet.Name == worksheet)
+									worksheet = destination.Worksheet.Name;
+								newFormulaString = string.IsNullOrEmpty(worksheet) ? newFormulaString : ExcelRangeBase.GetFullAddress(worksheet, newFormulaString);
+								newFormula = new ExcelAddress(newFormulaString);
+							}
 						}
 						var newHostCellAddress = this.myWorkbook.Package.FormulaManager.UpdateFormulaReferences(sparkline.HostCell.Address, destination._fromRow - this._fromRow, destination._fromCol - this._fromCol, 0, 0, this.WorkSheet, this.WorkSheet, true);
 						if (newGroup == null)
@@ -1340,7 +1341,6 @@ namespace OfficeOpenXml
 							newGroup.CopyNodeStyle(group.TopNode);
 						}
 						var newSparkline = new ExcelSparkline(new ExcelAddress(newHostCellAddress), newFormula, newGroup, sparkline.NameSpaceManager);
-						this.Worksheet.Cells[newSparkline.HostCell.Address].Sparklines.Add(newSparkline);
 						newGroup.Sparklines.Add(newSparkline);
 					}
 				}

--- a/EPPlusTest/ExcelRangeBaseTest.cs
+++ b/EPPlusTest/ExcelRangeBaseTest.cs
@@ -279,6 +279,44 @@ namespace EPPlusTest
 				copy.Delete();
 			}
 		}
+
+		[TestMethod]
+		public void CopySparklineWithNoFormula()
+		{
+			var tempWorkbook = new FileInfo(Path.GetTempFileName());
+			try
+			{
+				using (var package = new ExcelPackage())
+				{
+					var worksheet = package.Workbook.Worksheets.Add("Sheet");
+					var worksheetSparklineGroups = worksheet.SparklineGroups.SparklineGroups;
+
+					var sparklineGroup = new OfficeOpenXml.Drawing.Sparkline.ExcelSparklineGroup(worksheet, worksheet.NameSpaceManager);
+					// Use NULL for Formula
+					var sparkline = new OfficeOpenXml.Drawing.Sparkline.ExcelSparkline(new ExcelAddress("C3"), null, sparklineGroup, worksheet.NameSpaceManager);
+					sparklineGroup.Sparklines.Add(sparkline);
+					worksheet.SparklineGroups.SparklineGroups.Add(sparklineGroup);
+					package.SaveAs(tempWorkbook);
+				}
+				using (var package = new ExcelPackage(tempWorkbook))
+				{
+					var worksheet = package.Workbook.Worksheets["Sheet"];
+					var sparklineGroups = worksheet.SparklineGroups;
+					Assert.AreEqual(1, sparklineGroups.SparklineGroups.Count);
+					Assert.AreEqual(1, sparklineGroups.SparklineGroups[0].Sparklines.Count);
+					var origin = worksheet.Cells["C3"];
+					var target = worksheet.Cells["E5"];
+					origin.Copy(target);
+					Assert.AreEqual(2, sparklineGroups.SparklineGroups.Count);
+					Assert.AreEqual(1, sparklineGroups.SparklineGroups[0].Sparklines.Count);
+					Assert.AreEqual(1, sparklineGroups.SparklineGroups[1].Sparklines.Count);
+				}
+			}
+			finally
+			{
+				tempWorkbook.Delete();
+			}
+		}
 		#endregion
 
 		#region Shared Formula Overwrite Tests


### PR DESCRIPTION
Removed unnecessary sparkline collection on ExcelRangeBase.