### PR TITLE
Bugs/1273 offset uses wrong sheet

### DIFF
--- a/EPPlus/EPPlus.csproj
+++ b/EPPlus/EPPlus.csproj
@@ -543,6 +543,7 @@
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\Row.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\Rows.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\VLookup.cs" />
+    <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\WTOffset.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\CharFunction.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\Concatenate.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\CStr.cs" />

--- a/EPPlus/EPPlus.csproj
+++ b/EPPlus/EPPlus.csproj
@@ -543,7 +543,7 @@
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\Row.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\Rows.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\VLookup.cs" />
-    <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\WTOffset.cs" />
+    <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\OffsetAddress.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\CharFunction.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\Concatenate.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Text\CStr.cs" />

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -1322,7 +1322,21 @@ namespace OfficeOpenXml
 		public ExcelAddress(int fromRow, int fromCol, int toRow, int toColumn)
 			: base(fromRow, fromCol, toRow, toColumn)
 		{
-			_ws = "";
+			_ws = string.Empty;
+		}
+
+		/// <summary>
+		/// Creates an instance of <see cref="ExcelAddress"/>.
+		/// </summary>
+		/// <param name="worksheet">A worksheet to assign the address.</param>
+		/// <param name="fromRow">start row</param>
+		/// <param name="fromCol">start column</param>
+		/// <param name="toRow">End row</param>
+		/// <param name="toColumn">End column</param>
+		public ExcelAddress(string worksheet, int fromRow, int fromCol, int toRow, int toColumn)
+			: base(fromRow, fromCol, toRow, toColumn)
+		{
+			if (string.IsNullOrEmpty(this._ws)) this._ws = worksheet;
 		}
 
 		/// <summary>

--- a/EPPlus/FormulaParsing/CalculateExtentions.cs
+++ b/EPPlus/FormulaParsing/CalculateExtentions.cs
@@ -132,13 +132,29 @@ namespace OfficeOpenXml
 		}
 
 		/// <summary>
+		/// Calculate a specific <paramref name="formula"/> in the context of the specified <paramref name="worksheet"/>, 
+		/// <paramref name="row"/>, and <paramref name="column"/>.
+		/// </summary>
+		/// <param name="worksheet">The worksheet whose context should be used during the calculation for references that do not specify a sheet.</param>
+		/// <param name="formula">The formula to be calculated.</param>
+		/// <param name="row">The row within which to evaluate the specified formula.</param>
+		/// <param name="column">The column within which to evaluate the specified formula.</param>
+		/// <returns>The result of the calculation.</returns>
+		public static object Calculate(this ExcelWorksheet worksheet, string formula, int row, int column)
+		{
+			return Calculate(worksheet, formula, new ExcelCalculationOption(), row, column);
+		}
+
+		/// <summary>
 		/// Calculate a specific <paramref name="formula"/> in the context of the specified <paramref name="worksheet"/> with the specified <paramref name="options"/>.
 		/// </summary>
 		/// <param name="worksheet">The worksheet whose context should be used during the calculation for references that do not specify a sheet.</param>
 		/// <param name="formula">The formula to be calculated.</param>
 		/// <param name="options">The options for this calculation. At the moment, this does nothing.</param>
+		/// <param name="row">The row within which to evaluate the specified formula.</param>
+		/// <param name="column">The column within which to evaluate the specified formula.</param>
 		/// <returns>The result of the calculation.</returns>
-		public static object Calculate(this ExcelWorksheet worksheet, string formula, ExcelCalculationOption options)
+		public static object Calculate(this ExcelWorksheet worksheet, string formula, ExcelCalculationOption options, int row = -1, int column = -1)
 		{
 			try
 			{
@@ -154,7 +170,7 @@ namespace OfficeOpenXml
 
 				CalcChain(worksheet.Workbook, parser, dc);
 
-				return parser.ParseCell(f.Tokens, worksheet.Name, -1, -1);
+				return parser.ParseCell(f.Tokens, worksheet.Name, row, column);
 			}
 			catch (Exception ex)
 			{

--- a/EPPlus/FormulaParsing/DependencyChain/DependencyChainFactory.cs
+++ b/EPPlus/FormulaParsing/DependencyChain/DependencyChainFactory.cs
@@ -323,8 +323,6 @@ namespace OfficeOpenXml.FormulaParsing
 				}
 				else if (t.TokenType == TokenType.Function && t.Value.ToUpper() == Offset.Name)
 				{
-					// TODO: Handle legitimate CircularReferenceExceptions
-					// May need to use Calculate(...)'s row and column to check for legitimate circular references?
 					var stringBuilder = new StringBuilder($"{OffsetAddress.Name}(");
 					int offsetStartIndex = f.tokenIx;
 					int parenCount = 1;
@@ -340,7 +338,7 @@ namespace OfficeOpenXml.FormulaParsing
 					ExcelRange cell = ws.Cells[f.Row, f.Column];
 					string originalFormula = cell.Formula;
 					string addressOffsetFormula = stringBuilder.ToString();
-					stringBuilder = new StringBuilder();
+					stringBuilder.Clear();
 					for (int i = 0; i < f.Tokens.Count; i++)
 					{
 						if (i == offsetStartIndex)
@@ -397,7 +395,8 @@ namespace OfficeOpenXml.FormulaParsing
 						//Check for circular references
 						foreach (var par in stack)
 						{
-							if (ExcelAddressBase.GetCellID(par.ws.SheetID, par.iterator.Row, par.iterator.Column) == id)
+							if (ExcelAddressBase.GetCellID(par.ws.SheetID, par.iterator.Row, par.iterator.Column) == id 
+								|| ExcelAddressBase.GetCellID(par.ws.SheetID, par.Row, par.Column) == id)
 							{
 								if (options.AllowCircularReferences == false)
 								{

--- a/EPPlus/FormulaParsing/DependencyChain/DependencyChainFactory.cs
+++ b/EPPlus/FormulaParsing/DependencyChain/DependencyChainFactory.cs
@@ -325,7 +325,7 @@ namespace OfficeOpenXml.FormulaParsing
 				{
 					// TODO: Handle legitimate CircularReferenceExceptions
 					// May need to use Calculate(...)'s row and column to check for legitimate circular references?
-					var stringBuilder = new StringBuilder($"{WTOffset.Name}(");
+					var stringBuilder = new StringBuilder($"{OffsetAddress.Name}(");
 					int offsetStartIndex = f.tokenIx;
 					int parenCount = 1;
 					for (f.tokenIx += 2; parenCount > 0 && f.tokenIx < f.Tokens.Count; f.tokenIx++)

--- a/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -183,7 +183,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			this.Functions["index"] = new Index();
 			this.Functions["indirect"] = new Indirect();
 			this.Functions["offset"] = new Offset() { SkipArgumentEvaluation = true };
-			this.Functions["wtoffset"] = new WTOffset() { SkipArgumentEvaluation = true };
+			this.Functions["offsetaddress"] = new OffsetAddress() { SkipArgumentEvaluation = true };
 			// Date
 			this.Functions["date"] = new Date();
 			this.Functions["today"] = new Today();

--- a/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -183,6 +183,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			this.Functions["index"] = new Index();
 			this.Functions["indirect"] = new Indirect();
 			this.Functions["offset"] = new Offset() { SkipArgumentEvaluation = true };
+			this.Functions["wtoffset"] = new WTOffset() { SkipArgumentEvaluation = true };
 			// Date
 			this.Functions["date"] = new Date();
 			this.Functions["today"] = new Today();

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -102,5 +102,30 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 
 			return lookupArgs.RangeLookup ? _compileResultFactory.Create(lastLookupValue) : new CompileResult(eErrorType.NA);
 		}
+
+		protected ExcelAddress CalculateOffset(FunctionArgument[] arguments, ParsingContext context)
+		{
+			var startRange = ArgToString(arguments, 0);
+			var rowOffset = ArgToInt(arguments, 1);
+			var columnOffset = ArgToInt(arguments, 2);
+			int width = 0, height = 0;
+			if (arguments.Length > 3)
+				height = ArgToInt(arguments, 3);
+			if (arguments.Length > 4)
+				width = ArgToInt(arguments, 4);
+			if ((arguments.Length > 3 && height == 0) || (arguments.Length > 4 && width == 0))
+				return null;
+			var address = new ExcelAddress(startRange);
+			string targetWorksheetName;
+			if (string.IsNullOrEmpty(address.WorkSheet))
+				targetWorksheetName = context.Scopes.Current.Address.Worksheet;
+			else
+				targetWorksheetName = address.WorkSheet;
+			var fromRow = address._fromRow + rowOffset;
+			var fromCol = address._fromCol + columnOffset;
+			var toRow = (height != 0 ? height : address._toRow) + rowOffset;
+			var toCol = (width != 0 ? width : address._toCol) + columnOffset;
+			return new ExcelAddress(targetWorksheetName, fromRow, fromCol, toRow, toCol);
+		}
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -118,7 +118,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			var address = new ExcelAddress(startRange);
 			string targetWorksheetName;
 			if (string.IsNullOrEmpty(address.WorkSheet))
-				targetWorksheetName = context.Scopes.Current.Address.Worksheet;
+				targetWorksheetName = context.Scopes?.Current?.Address?.Worksheet;
 			else
 				targetWorksheetName = address.WorkSheet;
 			var fromRow = address._fromRow + rowOffset;

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
@@ -10,10 +10,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	/// <remarks>
 	/// This function is used internally to calculate an OFFSET( ) function's dependencies before calculation.
 	/// </remarks>
-	public class WTOffset : LookupFunction
+	public class OffsetAddress : LookupFunction
 	{
 		#region Constants
-		public const string Name = "WTOFFSET";
+		public const string Name = "OFFSETADDRESS";
 		#endregion
 
 		#region ExcelFunction Overrides

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/WTOffset.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/WTOffset.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using OfficeOpenXml.FormulaParsing.ExpressionGraph;
+
+namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
+{
+	/// <summary>
+	/// A function which takes the same arguments as the OFFSET( ) function and calculates the address offset.
+	/// </summary>
+	/// <remarks>
+	/// This function is used internally to calculate an OFFSET( ) function's dependencies before calculation.
+	/// </remarks>
+	public class WTOffset : LookupFunction
+	{
+		#region Constants
+		public const string Name = "WTOFFSET";
+		#endregion
+
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>An address range <see cref="CompileResult"/> if successful, otherwise an error result.</returns>
+		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
+		{
+			var functionArguments = arguments as FunctionArgument[] ?? arguments.ToArray();
+			if (this.ArgumentsAreValid(functionArguments, 3, out eErrorType argumentError) == false)
+				return new CompileResult(argumentError);
+			ExcelAddress offset = base.CalculateOffset(functionArguments, context);
+			if (offset == null)
+				return new CompileResult(eErrorType.Ref);
+			return new CompileResult(offset.FullAddress, DataType.String);
+		}
+		#endregion
+	}
+}

--- a/EPPlusTest/EPPlusTest.csproj
+++ b/EPPlusTest/EPPlusTest.csproj
@@ -223,6 +223,7 @@
     <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\MatchTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Math\SumIfsTests.cs" />
     <Compile Include="FormulaParsing\Excel\Functions\Logical\IfErrorTests.cs" />
+    <Compile Include="FormulaParsing\Excel\Functions\RefAndLookup\OffsetTests.cs" />
     <Compile Include="FormulaParsing\ExpressionGraph\CompileResultFactoryTests.cs" />
     <Compile Include="FormulaParsing\ExpressionGraph\CompileResultTests.cs" />
     <Compile Include="FormulaParsing\ExpressionGraph\FunctionCompilers\FunctionCompilerFactoryTests.cs" />

--- a/EPPlusTest/FormulaParsing/CalculationExtensionsTest.cs
+++ b/EPPlusTest/FormulaParsing/CalculationExtensionsTest.cs
@@ -11,7 +11,7 @@ namespace EPPlusTest.FormulaParsing
 	[TestClass]
 	public class CalculationExtensionsTest
 	{
-		#region Calculate ExcelWorkbook
+		#region Calculate ExcelWorkbook Tests
 		[TestMethod]
 		[ExpectedException(typeof(OperationCanceledException))]
 		public void CalculateExcelWorkbookAllowsOperationCanceledExceptionsThrough()
@@ -26,7 +26,7 @@ namespace EPPlusTest.FormulaParsing
 		}
 		#endregion
 
-		#region Calculate ExcelWorksheet
+		#region Calculate ExcelWorksheet Tests
 		[TestMethod]
 		[ExpectedException(typeof(OperationCanceledException))]
 		public void CalculateExcelWorksheetAllowsOperationCanceledExceptionsThrough()
@@ -41,7 +41,7 @@ namespace EPPlusTest.FormulaParsing
 		}
 		#endregion
 
-		#region Calculate ExcelRange
+		#region Calculate ExcelRange Tests
 		[TestMethod]
 		[ExpectedException(typeof(OperationCanceledException))]
 		public void CalculateExcelRangeAllowsOperationCanceledExceptionsThrough()
@@ -52,6 +52,48 @@ namespace EPPlusTest.FormulaParsing
 				package.Workbook.FormulaParserManager.AddOrReplaceFunction("Func", new CanceledFunction());
 				worksheet.Cells[3, 3].Formula = "Func()";
 				worksheet.Cells[3, 3].Calculate();
+			}
+		}
+		#endregion
+
+		#region Calculate Function String Tests
+		[TestMethod]
+		public void CalculateFunctionString()
+		{
+			using (var package = new ExcelPackage())
+			using (var worksheet = package.Workbook.Worksheets.Add("Sheet"))
+			{
+				worksheet.Cells["E5"].Formula = "=ROW()";
+				Assert.AreEqual(null, worksheet.Cells["E5"].Value);
+				var result = worksheet.Calculate("E5 * 5");
+				Assert.AreEqual(5, worksheet.Cells["E5"].Value);
+				Assert.AreEqual(25d, result);
+			}
+		}
+
+		[TestMethod]
+		public void CalculateFunctionStringDefaultAddress()
+		{
+			using (var package = new ExcelPackage())
+			using (var worksheet = package.Workbook.Worksheets.Add("Sheet"))
+			{
+				var result = worksheet.Calculate("ROW()");
+				Assert.AreEqual(-1, result);
+				result = worksheet.Calculate("COLUMN()");
+				Assert.AreEqual(-1, result);
+			}
+		}
+
+		[TestMethod]
+		public void CalculateFunctionStringSpecifiedAddress()
+		{
+			using (var package = new ExcelPackage())
+			using (var worksheet = package.Workbook.Worksheets.Add("Sheet"))
+			{
+				var result = worksheet.Calculate("ROW()", 5, 6);
+				Assert.AreEqual(5, result);
+				result = worksheet.Calculate("COLUMN()", 5, 6);
+				Assert.AreEqual(6, result);
 			}
 		}
 		#endregion

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using EPPlusTest.FormulaParsing.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Excel.Functions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
+
+namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
+{
+	public class OffsetTests
+	{
+		#region (WT)Offset Tests
+		[TestMethod]
+		public void OffsetReturnsPoundValueIfTooFewArgumentsAreSupplied()
+		{
+			var func = new Offset();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs("B2", 2);
+			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
+		}
+
+		[TestMethod]
+		public void OffsetReturnsPoundRefIfInvalidArgumentsAreSupplied()
+		{
+			var func = new Offset();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs("B2", 0, 0, 0, 0);
+			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Ref, eErrorType.Ref, true);
+		}
+
+		[TestMethod]
+		public void OffsetWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new Offset();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
+		}
+		#endregion
+
+		#region Helper Methods
+		private void ValidateOffsetAndWTOffset(IEnumerable<FunctionArgument> arguments, ParsingContext context, object expectedOffsetResult, object expectedWTOffsetResult, bool errorExpected = false)
+		{
+			Offset offsetFunction = new Offset();
+			WTOffset wTOffsetFunction = new WTOffset();
+			var offsetResult = offsetFunction.Execute(arguments, context);
+			var wTOffsetResult = wTOffsetFunction.Execute(arguments, context);
+			if (errorExpected)
+			{
+				Assert.AreEqual(expectedOffsetResult, ((ExcelErrorValue)offsetResult.Result).Type);
+				Assert.AreEqual(expectedWTOffsetResult, ((ExcelErrorValue)wTOffsetResult.Result).Type);
+			}
+			else
+			{
+				Assert.AreEqual(expectedOffsetResult, offsetResult);
+				Assert.AreEqual(expectedWTOffsetResult, wTOffsetResult);
+			}
+		}
+		#endregion
+	}
+}

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
@@ -8,13 +8,13 @@ using OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup;
 
 namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {
+	[TestClass]
 	public class OffsetTests
 	{
 		#region Offset/OffsetAddress Tests
 		[TestMethod]
 		public void OffsetReturnsPoundValueIfTooFewArgumentsAreSupplied()
 		{
-			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs("B2", 2);
 			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
@@ -23,7 +23,6 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 		[TestMethod]
 		public void OffsetReturnsPoundRefIfInvalidArgumentsAreSupplied()
 		{
-			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs("B2", 0, 0, 0, 0);
 			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Ref, eErrorType.Ref, true);
@@ -32,7 +31,6 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 		[TestMethod]
 		public void OffsetWithInvalidArgumentReturnsPoundValue()
 		{
-			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs();
 			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Value, eErrorType.Value, true);

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/OffsetTests.cs
@@ -10,14 +10,14 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class OffsetTests
 	{
-		#region (WT)Offset Tests
+		#region Offset/OffsetAddress Tests
 		[TestMethod]
 		public void OffsetReturnsPoundValueIfTooFewArgumentsAreSupplied()
 		{
 			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs("B2", 2);
-			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
+			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
 		}
 
 		[TestMethod]
@@ -26,7 +26,7 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs("B2", 0, 0, 0, 0);
-			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Ref, eErrorType.Ref, true);
+			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Ref, eErrorType.Ref, true);
 		}
 
 		[TestMethod]
@@ -35,26 +35,26 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions.RefAndLookup
 			var func = new Offset();
 			var parsingContext = ParsingContext.Create();
 			var args = FunctionsHelper.CreateArgs();
-			this.ValidateOffsetAndWTOffset(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
+			this.ValidateOffsetAndOffsetAddress(args, parsingContext, eErrorType.Value, eErrorType.Value, true);
 		}
 		#endregion
 
 		#region Helper Methods
-		private void ValidateOffsetAndWTOffset(IEnumerable<FunctionArgument> arguments, ParsingContext context, object expectedOffsetResult, object expectedWTOffsetResult, bool errorExpected = false)
+		private void ValidateOffsetAndOffsetAddress(IEnumerable<FunctionArgument> arguments, ParsingContext context, object expectedOffsetResult, object expectedOffsetAddressResult, bool errorExpected = false)
 		{
 			Offset offsetFunction = new Offset();
-			WTOffset wTOffsetFunction = new WTOffset();
+			OffsetAddress offsetAddressFunction = new OffsetAddress();
 			var offsetResult = offsetFunction.Execute(arguments, context);
-			var wTOffsetResult = wTOffsetFunction.Execute(arguments, context);
+			var offsetAddressResult = offsetAddressFunction.Execute(arguments, context);
 			if (errorExpected)
 			{
 				Assert.AreEqual(expectedOffsetResult, ((ExcelErrorValue)offsetResult.Result).Type);
-				Assert.AreEqual(expectedWTOffsetResult, ((ExcelErrorValue)wTOffsetResult.Result).Type);
+				Assert.AreEqual(expectedOffsetAddressResult, ((ExcelErrorValue)offsetAddressResult.Result).Type);
 			}
 			else
 			{
 				Assert.AreEqual(expectedOffsetResult, offsetResult);
-				Assert.AreEqual(expectedWTOffsetResult, wTOffsetResult);
+				Assert.AreEqual(expectedOffsetAddressResult, offsetAddressResult);
 			}
 		}
 		#endregion

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
@@ -16,17 +16,11 @@ namespace EPPlusTest.Excel.Functions
 	[TestClass]
 	public class RefAndLookupTests
 	{
+		#region Constants
 		const string WorksheetName = null;
+		#endregion
 
-		[TestMethod]
-		public void AddressWithTooFewArgumentsReturnsPoundValue()
-		{
-			var function = new OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Address();
-			var args = FunctionsHelper.CreateArgs("One Arg Only");
-			var result = function.Execute(args, null);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
+		#region LookupArguments Tests
 		[TestMethod]
 		public void LookupArgumentsShouldSetSearchedValue()
 		{
@@ -124,7 +118,9 @@ namespace EPPlusTest.Excel.Functions
 			var lookupArgs = new LookupArguments(args, ParsingContext.Create());
 			Assert.IsTrue(lookupArgs.RangeLookup);
 		}
+		#endregion
 
+		#region (H/V)Lookup Tests
 		[TestMethod]
 		public void VLookupShouldReturnResultFromMatchingRow()
 		{
@@ -185,6 +181,16 @@ namespace EPPlusTest.Excel.Functions
 			parsingContext.ExcelDataProvider = provider;
 			var result = func.Execute(args, parsingContext);
 			Assert.AreEqual(1, result.Result);
+		}
+
+		[TestMethod]
+		public void VLookupWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new VLookup();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
 		}
 
 		[TestMethod]
@@ -250,6 +256,16 @@ namespace EPPlusTest.Excel.Functions
 			parsingContext.ExcelDataProvider = provider;
 			var result = func.Execute(args, parsingContext);
 			Assert.AreEqual(result.DataType, DataType.ExcelError);
+		}
+
+		[TestMethod]
+		public void HLookupWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new HLookup();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
 		}
 
 		[TestMethod]
@@ -336,6 +352,18 @@ namespace EPPlusTest.Excel.Functions
 			Assert.AreEqual("B", result.Result);
 		}
 
+		[TestMethod]
+		public void LookupWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new Lookup();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
+		}
+		#endregion
+
+		#region Match Tests
 		[TestMethod]
 		public void MatchShouldReturnIndexOfMatchingValHorizontal_MatchTypeExact()
 		{
@@ -438,6 +466,18 @@ namespace EPPlusTest.Excel.Functions
 		}
 
 		[TestMethod]
+		public void MatchWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new Match();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
+		}
+		#endregion
+
+		#region Row(s)/Column(s) Tests
+		[TestMethod]
 		public void RowShouldReturnRowFromCurrentScopeIfNoAddressIsSupplied()
 		{
 			var func = new Row();
@@ -500,6 +540,16 @@ namespace EPPlusTest.Excel.Functions
 		}
 
 		[TestMethod]
+		public void RowsWithInvalidArgumentReturnsPoundValue()
+		{
+			var func = new Rows();
+			var parsingContext = ParsingContext.Create();
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
+		}
+
+		[TestMethod]
 		public void ColumnssShouldReturnNbrOfRowsSuppliedRange()
 		{
 			var func = new Columns();
@@ -510,14 +560,17 @@ namespace EPPlusTest.Excel.Functions
 		}
 
 		[TestMethod]
-		public void ChooseShouldReturnItemByIndex()
+		public void ColumnsWithInvalidArgumentReturnsPoundValue()
 		{
-			var func = new Choose();
+			var func = new Columns();
 			var parsingContext = ParsingContext.Create();
-			var result = func.Execute(FunctionsHelper.CreateArgs(1, "A", "B"), parsingContext);
-			Assert.AreEqual("A", result.Result);
+			var args = FunctionsHelper.CreateArgs();
+			var result = func.Execute(args, parsingContext);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
 		}
+		#endregion
 
+		#region Address Tests
 		[TestMethod]
 		public void AddressShouldReturnAddressByIndexWithDefaultRefType()
 		{
@@ -551,6 +604,15 @@ namespace EPPlusTest.Excel.Functions
 			Assert.AreEqual("Worksheet1!B1", result.Result);
 		}
 
+		[TestMethod]
+		public void AddressWithTooFewArgumentsReturnsPoundValue()
+		{
+			var function = new OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup.Address();
+			var args = FunctionsHelper.CreateArgs("One Arg Only");
+			var result = function.Execute(args, null);
+			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
+		}
+
 		[TestMethod, ExpectedException(typeof(InvalidOperationException))]
 		public void AddressShouldThrowIfR1C1FormatIsSpecified()
 		{
@@ -560,96 +622,18 @@ namespace EPPlusTest.Excel.Functions
 			parsingContext.ExcelDataProvider.Stub(x => x.ExcelMaxRows).Return(10);
 			var result = func.Execute(FunctionsHelper.CreateArgs(1, 2, (int)ExcelReferenceType.RelativeRowAndColumn, false), parsingContext);
 		}
+		#endregion
 
+		#region Choose Tests
 		[TestMethod]
-		public void OffsetReturnsPoundValueIfTooFewArgumentsAreSupplied()
+		public void ChooseShouldReturnItemByIndex()
 		{
-			var func = new Offset();
+			var func = new Choose();
 			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs("B2", 2);
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
+			var result = func.Execute(FunctionsHelper.CreateArgs(1, "A", "B"), parsingContext);
+			Assert.AreEqual("A", result.Result);
 		}
-
-		[TestMethod]
-		public void OffsetReturnsPoundRefIfInvalidArgumentsAreSupplied()
-		{
-			var func = new Offset();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs("B2", 0, 0, 0, 0);
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Ref, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void ColumnsWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new Columns();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void HLookupWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new HLookup();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void LookupWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new Lookup();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void MatchWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new Match();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void OffsetWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new Offset();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void RowsWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new Rows();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
-
-		[TestMethod]
-		public void VLookupWithInvalidArgumentReturnsPoundValue()
-		{
-			var func = new VLookup();
-			var parsingContext = ParsingContext.Create();
-			var args = FunctionsHelper.CreateArgs();
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual(eErrorType.Value, ((ExcelErrorValue)result.Result).Type);
-		}
+		#endregion
 
 		#region Helper Methods
 		private ParsingContext BuildParsingContext(ExcelPackage excelPackage)

--- a/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/OperatorsTests.cs
@@ -199,6 +199,109 @@ namespace EPPlusTest.Excel
 			Assert.AreEqual(true, Operator.LessThan.Apply(new CompileResult(false, DataType.Boolean), new CompileResult(true, DataType.Boolean)).Result);
 			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(new CompileResult(false, DataType.Boolean), new CompileResult(true, DataType.Boolean)).Result);
 		}
+
+		[TestMethod]
+		public void OperatorLogicalOperatorsShouldCorrectlyCompareLogicalAndEmptyValues()
+		{
+			Assert.AreEqual(true, Operator.GreaterThan.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(true, Operator.EqualsTo.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(false, Operator.NotEqualsTo.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+
+			Assert.AreEqual(false, Operator.LessThan.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(false, Operator.LessThan.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+
+			Assert.AreEqual(false, Operator.LessThanOrEqual.Apply(new CompileResult(true, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(true, DataType.Boolean)).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(new CompileResult(false, DataType.Boolean), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(false, DataType.Boolean)).Result);
+		}
+
+		[TestMethod]
+		public void OperatorLogicalOperatorsShouldCorrectlyCompareNumericAndEmptyValues()
+		{
+			Assert.AreEqual(true, Operator.GreaterThan.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(false, Operator.GreaterThanOrEqual.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+
+			Assert.AreEqual(false, Operator.LessThan.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(true, Operator.LessThan.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+
+			Assert.AreEqual(false, Operator.LessThanOrEqual.Apply(new CompileResult(1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(1d, DataType.Decimal)).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(new CompileResult(-1d, DataType.Decimal), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(-1d, DataType.Decimal)).Result);
+		}
+
+		[TestMethod]
+		public void OperatorLogicalOperatorsShouldCorrectlyCompareStringAndEmptyValues()
+		{
+			const string value = "sdflkjsdlfk";
+			Assert.AreEqual(true, Operator.GreaterThan.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThan.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.GreaterThanOrEqual.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(true, Operator.EqualsTo.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.EqualsTo.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(false, Operator.NotEqualsTo.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.NotEqualsTo.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+
+			Assert.AreEqual(false, Operator.LessThan.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(false, Operator.LessThan.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(false, Operator.LessThan.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+
+			Assert.AreEqual(false, Operator.LessThanOrEqual.Apply(new CompileResult(value, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(value, DataType.String)).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(new CompileResult(string.Empty, DataType.String), CompileResult.Empty).Result);
+			Assert.AreEqual(true, Operator.LessThanOrEqual.Apply(CompileResult.Empty, new CompileResult(string.Empty, DataType.String)).Result);
+		}
 		#endregion
 
 		#region Operator Plus Tests

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
 using OfficeOpenXml.FormulaParsing;
+using OfficeOpenXml.FormulaParsing.Exceptions;
 using Rhino.Mocks;
 
 namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
@@ -10,11 +11,14 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 	[TestClass]
 	public class RefAndLookupTests : FormulaParserTestBase
 	{
+		#region Class Variables
 		private ExcelDataProvider _excelDataProvider;
 		const string WorksheetName = null;
 		private ExcelPackage _package;
 		private ExcelWorksheet _worksheet;
+		#endregion
 
+		#region Test Setup
 		[TestInitialize]
 		public void Initialize()
 		{
@@ -30,7 +34,9 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		{
 			_package.Dispose();
 		}
+		#endregion
 
+		#region <X>Lookup Tests
 		[TestMethod]
 		public void VLookupShouldReturnCorrespondingValue()
 		{
@@ -105,17 +111,9 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 			var result = _parser.Parse("LOOKUP(4, " + lookupAddress + ")");
 			Assert.AreEqual(1, result);
 		}
+		#endregion
 
-		[TestMethod]
-		public void MatchShouldReturnIndexOfMatchingValue()
-		{
-			var lookupAddress = "A1:A2";
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(3);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(5);
-			var result = _parser.Parse("MATCH(3, " + lookupAddress + ")");
-			Assert.AreEqual(1, result);
-		}
-
+		#region Row/Column Tests
 		[TestMethod]
 		public void RowShouldReturnRowNumber()
 		{
@@ -179,32 +177,9 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 			var result = _parser.Parse("Choose(1, \"A\", \"B\")");
 			Assert.AreEqual("A", result);
 		}
+		#endregion
 
-		[TestMethod]
-		public void AddressShouldReturnCorrectResult()
-		{
-			_excelDataProvider.Stub(x => x.ExcelMaxRows).Return(12345);
-			var result = _parser.Parse("Address(1, 1)");
-			Assert.AreEqual("$A$1", result);
-		}
-
-		[TestMethod]
-		public void IndirectShouldReturnARange()
-		{
-			using (var package = new ExcelPackage(new MemoryStream()))
-			{
-				var s1 = package.Workbook.Worksheets.Add("Test");
-				s1.Cells["A1:A2"].Value = 2;
-				s1.Cells["A3"].Formula = "SUM(Indirect(\"A1:A2\"))";
-				s1.Calculate();
-				Assert.AreEqual(4d, s1.Cells["A3"].Value);
-
-				s1.Cells["A4"].Formula = "SUM(Indirect(\"A1:A\" & \"2\"))";
-				s1.Calculate();
-				Assert.AreEqual(4d, s1.Cells["A4"].Value);
-			}
-		}
-
+		#region Offset Tests
 		[TestMethod]
 		public void OffsetShouldReturnASingleValue()
 		{
@@ -300,6 +275,156 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 			}
 		}
 
+		[TestMethod]
+		public void OffsetShouldGetValueOnCorrectSheet()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				var sheet2 = package.Workbook.Worksheets.Add("Sheet2");
+				sheet1.Cells["E5"].Value = "Bad";
+				sheet2.Cells["E5"].Value = "Good";
+				sheet2.Cells["C3"].Formula = "OFFSET(D4, 1, 1)";
+				sheet2.Calculate();
+				Assert.AreEqual("Good", sheet2.Cells["C3"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void OffsetShouldGetCalculatedValue()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["E5"].Formula = "CONCATENATE(\"Y\",\"o\")";
+				sheet1.Cells["C3"].Formula = "OFFSET(D4, 1, 1)";
+				sheet1.Cells["C3"].Calculate();
+				Assert.AreEqual("Yo", sheet1.Cells["C3"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void OffsetWithSemiCircularReferenceGetsValue()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["D3"].Formula = "IF(TRUE, 0, E3)";
+				sheet1.Cells["D4"].Value = "Good";
+				sheet1.Cells["E3"].Formula = "OFFSET(D3, 1,0)";
+				sheet1.Cells["E3"].Calculate();
+				Assert.AreEqual("Good", sheet1.Cells["E3"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void OffsetWithSimpleSemiCircularReferenceThrowsException()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["E3"].Formula = "offset(E3, 1,0)";
+				sheet1.Cells["E4"].Value = "Good";
+				sheet1.Cells["E3"].Calculate();
+				Assert.AreEqual("Good", sheet1.Cells["E3"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void OffsetWithSemiCircularChainedReferenceGetsValue()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["D3"].Formula = "IF(TRUE, 0, E3)";
+				sheet1.Cells["E3"].Formula = "OFFSET(D3, 1,0)";
+				sheet1.Cells["D4"].Formula = @"INDIRECT(""E4"")";
+				sheet1.Cells["E3"].Value = "Good";
+				sheet1.Cells["E3"].Calculate();
+				Assert.AreEqual("Good", sheet1.Cells["E3"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void OffsetsWithSemiCircularChainedReferenceGetsValue()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["D3"].Formula = "SUM(OFFSET(C3, 1, 0), OFFSET(E3, 1, 0))";
+				sheet1.Cells["C3"].Formula = "=D3";
+				sheet1.Cells["C4"].Value = 10d;
+				sheet1.Cells["E3"].Formula = "=D3";
+				sheet1.Cells["E4"].Value = 5d;
+				sheet1.Cells["D3"].Calculate();
+				Assert.AreEqual(15d, sheet1.Cells["D3"].Value);
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(CircularReferenceException))]
+		public void OffsetWithCircularReferenceThrowsException()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["E3"].Formula = "offset(F3, 1,0)";
+				sheet1.Cells["F4"].Formula = "E3";
+				sheet1.Cells["E3"].Calculate();
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(CircularReferenceException))]
+		public void OffsetWithIndirectCircularReferenceThrowsException()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				sheet1.Cells["E3"].Formula = "OFFSET(D3, 1,0)";
+				sheet1.Cells["D4"].Formula = @"INDIRECT(""E4"")";
+				sheet1.Cells["E4"].Formula = "E3";
+				sheet1.Cells["E3"].Calculate();
+			}
+		}
+		#endregion
+
+		#region Miscellaneous Tests
+		[TestMethod]
+		public void AddressShouldReturnCorrectResult()
+		{
+			_excelDataProvider.Stub(x => x.ExcelMaxRows).Return(12345);
+			var result = _parser.Parse("Address(1, 1)");
+			Assert.AreEqual("$A$1", result);
+		}
+
+		[TestMethod]
+		public void IndirectShouldReturnARange()
+		{
+			using (var package = new ExcelPackage(new MemoryStream()))
+			{
+				var s1 = package.Workbook.Worksheets.Add("Test");
+				s1.Cells["A1:A2"].Value = 2;
+				s1.Cells["A3"].Formula = "SUM(Indirect(\"A1:A2\"))";
+				s1.Calculate();
+				Assert.AreEqual(4d, s1.Cells["A3"].Value);
+
+				s1.Cells["A4"].Formula = "SUM(Indirect(\"A1:A\" & \"2\"))";
+				s1.Calculate();
+				Assert.AreEqual(4d, s1.Cells["A4"].Value);
+			}
+		}
+
+		[TestMethod]
+		public void MatchShouldReturnIndexOfMatchingValue()
+		{
+			var lookupAddress = "A1:A2";
+			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(3);
+			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(5);
+			var result = _parser.Parse("MATCH(3, " + lookupAddress + ")");
+			Assert.AreEqual(1, result);
+		}
+
 		[TestMethod, Ignore]
 		public void VLookupShouldHandleNames()
 		{
@@ -311,5 +436,6 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 				v = s1.Cells["X10"].Formula;
 			}
 		}
+		#endregion
 	}
 }

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
@@ -363,7 +363,7 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 
 		[TestMethod]
 		[ExpectedException(typeof(CircularReferenceException))]
-		public void OffsetWithCircularReferenceThrowsException()
+		public void OffsetWithSimpleCircularReferenceThrowsException()
 		{
 			using (var package = new ExcelPackage())
 			{
@@ -376,14 +376,32 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 
 		[TestMethod]
 		[ExpectedException(typeof(CircularReferenceException))]
-		public void OffsetWithIndirectCircularReferenceThrowsException()
+		public void OffsetWithCircularReferenceThrowsException()
 		{
 			using (var package = new ExcelPackage())
 			{
 				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
-				sheet1.Cells["E3"].Formula = "OFFSET(D3, 1,0)";
-				sheet1.Cells["D4"].Formula = @"INDIRECT(""E4"")";
-				sheet1.Cells["E4"].Formula = "E3";
+				sheet1.Cells["E3"].Formula = "offset(F3, 1,0)";
+				sheet1.Cells["F4"].Formula = "G4";
+				sheet1.Cells["G4"].Formula = "IF(TRUE, D3, C3)";
+				sheet1.Cells["D3"].Formula = "E3";
+				sheet1.Cells["E3"].Calculate();
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(CircularReferenceException))]
+		public void OffsetWithCrossSheetCircularReferenceThrowsException()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet1 = package.Workbook.Worksheets.Add("Sheet1");
+				var sheet2 = package.Workbook.Worksheets.Add("Sheet2");
+				sheet1.Cells["E3"].Formula = "offset(F3, 1,0)";
+				sheet1.Cells["F4"].Formula = "G4";
+				sheet1.Cells["G4"].Formula = "IF(TRUE, D3, C3)";
+				sheet1.Cells["D3"].Formula = "Sheet2!E3";
+				sheet2.Cells["E3"].Formula = "Sheet1!E3";
 				sheet1.Cells["E3"].Calculate();
 			}
 		}


### PR DESCRIPTION
Resolves bugs:
- Offset can uses incorrect sheet when not on first sheet,
- offset can incorrectly cause CircularReferenceExceptions,
- offset's dependencies can be incorrectly ordered in the dependency chain,
- some comparisons against empty values were incorrect.
Adds tests for OFFSET function and comparison operators.