### PR TITLE
Bugs/2390 invariant culture xlfn prefix

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
@@ -77,7 +77,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 		}
 
 		/// <summary>
-		/// Gets an <see cref="ExcelFunction"/> from the function name.
+		/// Gets an <see cref="ExcelFunction"/> from the function name, or null if a matching function was not found.
 		/// </summary>
 		/// <param name="name">The name of the function.</param>
 		/// <returns>The <see cref="ExcelFunction"/></returns>
@@ -88,11 +88,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			if (name.StartsWith(invariantCulturePrefix))
 				name = name.Remove(0, invariantCulturePrefix.Length);
 			if (!_functions.ContainsKey(name))
-			{
-				//throw new InvalidOperationException("Non supported function: " + name);
-				//throw new ExcelErrorValueException("Non supported function: " + name, ExcelErrorValue.Create(eErrorType.Name));
 				return null;
-			}
 			return _functions[name];
 		}
 

--- a/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
@@ -78,6 +78,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 
 		public virtual ExcelFunction GetFunction(string name)
 		{
+			string invariantCulturePrefix = "_xlfn.";
+			if (name.ToLower().StartsWith(invariantCulturePrefix))
+				name = name.Remove(0, invariantCulturePrefix.Length);
 			if (!_functions.ContainsKey(name.ToLower(CultureInfo.InvariantCulture)))
 			{
 				//throw new InvalidOperationException("Non supported function: " + name);

--- a/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
@@ -76,6 +76,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			}
 		}
 
+		/// <summary>
+		/// Gets an <see cref="ExcelFunction"/> from the function name.
+		/// </summary>
+		/// <param name="name">The name of the function.</param>
+		/// <returns>The <see cref="ExcelFunction"/></returns>
 		public virtual ExcelFunction GetFunction(string name)
 		{
 			string invariantCulturePrefix = "_xlfn.";

--- a/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/FunctionRepository.cs
@@ -79,15 +79,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 		public virtual ExcelFunction GetFunction(string name)
 		{
 			string invariantCulturePrefix = "_xlfn.";
-			if (name.ToLower().StartsWith(invariantCulturePrefix))
+			name = name.ToLower(CultureInfo.InvariantCulture);
+			if (name.StartsWith(invariantCulturePrefix))
 				name = name.Remove(0, invariantCulturePrefix.Length);
-			if (!_functions.ContainsKey(name.ToLower(CultureInfo.InvariantCulture)))
+			if (!_functions.ContainsKey(name))
 			{
 				//throw new InvalidOperationException("Non supported function: " + name);
 				//throw new ExcelErrorValueException("Non supported function: " + name, ExcelErrorValue.Create(eErrorType.Name));
 				return null;
 			}
-			return _functions[name.ToLower(CultureInfo.InvariantCulture)];
+			return _functions[name];
 		}
 
 		/// <summary>

--- a/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
@@ -46,6 +46,14 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
 			Assert.IsNotNull(function);
 			Assert.IsTrue(function is Abs);
 		}
+
+		[TestMethod]
+		public void GetFunctionForInvalidFunctionTest()
+		{
+			var functionRepository = FunctionRepository.Create();
+			var function = functionRepository.GetFunction("NOTAFUNCTION");
+			Assert.IsNull(function);
+		}
 		#endregion
 
 		#region Nested Classes

--- a/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/FunctionRepositoryTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.Excel.Functions;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Math;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers;
 
@@ -23,6 +25,26 @@ namespace EPPlusTest.FormulaParsing.Excel.Functions
 			Assert.IsTrue(functionRepository.CustomCompilers.ContainsKey(typeof(MyFunction)));
 			// Make sure reloading the module overwrites previous functions and compilers
 			functionRepository.LoadModule(new TestFunctionModule());
+		}
+		#endregion
+
+		#region GetFunction Tests
+		[TestMethod]
+		public void GetFunctionWithXlfnPrefix()
+		{
+			var functionRepository = FunctionRepository.Create();
+			var function = functionRepository.GetFunction("_xlfn.IF");
+			Assert.IsNotNull(function);
+			Assert.IsTrue(function is If);
+		}
+
+		[TestMethod]
+		public void GetFunctionTest()
+		{
+			var functionRepository = FunctionRepository.Create();
+			var function = functionRepository.GetFunction("ABS");
+			Assert.IsNotNull(function);
+			Assert.IsTrue(function is Abs);
 		}
 		#endregion
 


### PR DESCRIPTION
Some functions are stored with a "_xlfn." prefix in invariant culture. I stripped this prefix on fetching of functions so that these functions can still be resolved and evaluated. 