### PR TITLE
Fixed issue where getting relative formula of a named range throw an …

### DIFF
--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -47,6 +47,8 @@ namespace OfficeOpenXml
 		#region Class Variables
 		protected internal int _fromRow = -1, _toRow, _fromCol, _toCol;
 		protected internal bool _fromRowFixed, _fromColFixed, _toRowFixed, _toColFixed;
+		// True if the ExcelAddress represents a single rectangle with a full row or column (ie: C:C or $4:$9)
+		protected internal bool _isFullRow, _isFullColumn;
 		protected internal string _wb;
 		protected internal string _ws;
 		protected internal string _address;
@@ -506,7 +508,7 @@ namespace OfficeOpenXml
 			else
 			{
 				//Simple address
-				ExcelCellBase.GetRowColFromAddress(_address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed);
+				ExcelCellBase.GetRowColFromAddress(_address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed, out _isFullRow, out _isFullColumn);
 				_addresses = null;
 				_start = null;
 				_end = null;
@@ -755,7 +757,12 @@ namespace OfficeOpenXml
 			{
 				if (string.IsNullOrEmpty(_ws) || !string.IsNullOrEmpty(ws)) _ws = ws;
 				_firstAddress = address;
-				GetRowColFromAddress(address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed);
+				GetRowColFromAddress(address, out _fromRow, out _fromCol, out _toRow, out _toCol, out _fromRowFixed, out _fromColFixed, out _toRowFixed, out _toColFixed, out bool isFullRow, out bool isFullColumn);
+				if (!isMulti)
+				{
+					this._isFullRow = isFullRow;
+					this._isFullColumn = isFullColumn;
+				}
 			}
 			if (isMulti)
 			{

--- a/EPPlus/ExcelCellBase.cs
+++ b/EPPlus/ExcelCellBase.cs
@@ -374,7 +374,7 @@ namespace OfficeOpenXml
 		internal static bool GetRowColFromAddress(string CellAddress, out int FromRow, out int FromColumn, out int ToRow, out int ToColumn)
 		{
 			bool fixedFromRow, fixedFromColumn, fixedToRow, fixedToColumn;
-			return GetRowColFromAddress(CellAddress, out FromRow, out FromColumn, out ToRow, out ToColumn, out fixedFromRow, out fixedFromColumn, out fixedToRow, out fixedToColumn);
+			return GetRowColFromAddress(CellAddress, out FromRow, out FromColumn, out ToRow, out ToColumn, out fixedFromRow, out fixedFromColumn, out fixedToRow, out fixedToColumn, out _, out _);
 		}
 		/// <summary>
 		/// Get the row/columns for a Cell-address
@@ -389,9 +389,11 @@ namespace OfficeOpenXml
 		/// <param name="fixedToRow">Is the to row fixed?</param>
 		/// <param name="fixedToColumn">Is the to column fixed?</param>
 		/// <returns></returns>
-		internal static bool GetRowColFromAddress(string CellAddress, out int FromRow, out int FromColumn, out int ToRow, out int ToColumn, out bool fixedFromRow, out bool fixedFromColumn, out bool fixedToRow, out bool fixedToColumn)
+		internal static bool GetRowColFromAddress(string CellAddress, out int FromRow, out int FromColumn, out int ToRow, out int ToColumn, out bool fixedFromRow, out bool fixedFromColumn, out bool fixedToRow, out bool fixedToColumn, out bool isFullRow, out bool isFullColumn)
 		{
 			bool ret;
+			isFullRow = false;
+			isFullColumn = false;
 			if (CellAddress.IndexOf('[') > 0) //External reference or reference to Table or Pivottable.
 			{
 				FromRow = -1;
@@ -425,7 +427,16 @@ namespace OfficeOpenXml
 				string[] cells = CellAddress.Split(':');
 				ret = GetRowColFromAddress(cells[0], out FromRow, out FromColumn, out fixedFromRow, out fixedFromColumn);
 				if (ret)
+				{
 					ret = GetRowColFromAddress(cells[1], out ToRow, out ToColumn, out fixedToRow, out fixedToColumn);
+					if (ret)
+					{
+						if (FromRow == 0 && ToRow == 0)
+							isFullColumn = true;
+						if (FromColumn == 0 && ToColumn == 0)
+							 isFullRow = true;
+					}
+				}
 				else
 				{
 					GetRowColFromAddress(cells[1], out ToRow, out ToColumn, out fixedToRow, out fixedToColumn);

--- a/EPPlus/ExcelNamedRange.cs
+++ b/EPPlus/ExcelNamedRange.cs
@@ -156,10 +156,20 @@ namespace OfficeOpenXml
 					// Do not update external references.
 					if (!string.IsNullOrEmpty(address?.Workbook))
 						continue;
-					int fromRow = this.GetRelativeLocation(address._fromRowFixed, address._fromRow, relativeRow, ExcelPackage.MaxRows);
-					int fromColumn = this.GetRelativeLocation(address._fromColFixed, address._fromCol, relativeColumn, ExcelPackage.MaxColumns);
-					int toRow = this.GetRelativeLocation(address._toRowFixed, address._toRow, relativeRow, ExcelPackage.MaxRows);
-					int toColumn = this.GetRelativeLocation(address._toColFixed, address._toCol, relativeColumn, ExcelPackage.MaxColumns);
+					int fromRow = address._fromRow;
+					int fromColumn = address._fromCol;
+					int toRow = address._toRow;
+					int toColumn = address._toCol;
+					if (!address._isFullColumn)
+					{
+						fromRow = this.GetRelativeLocation(address._fromRowFixed, address._fromRow, relativeRow, ExcelPackage.MaxRows);
+						toRow = this.GetRelativeLocation(address._toRowFixed, address._toRow, relativeRow, ExcelPackage.MaxRows);
+					}
+					if (!address._isFullRow)
+					{
+						fromColumn = this.GetRelativeLocation(address._fromColFixed, address._fromCol, relativeColumn, ExcelPackage.MaxColumns);
+						toColumn = this.GetRelativeLocation(address._toColFixed, address._toCol, relativeColumn, ExcelPackage.MaxColumns);
+					}
 					var updatedAddress = ExcelCellBase.GetAddress(fromRow, fromColumn, toRow, toColumn, address._fromRowFixed, address._fromColFixed, address._toRowFixed, address._toColFixed);
 					token.Value = ExcelCellBase.GetFullAddress(address.WorkSheet, updatedAddress);
 				}

--- a/EPPlusTest/ExcelAddressTest.cs
+++ b/EPPlusTest/ExcelAddressTest.cs
@@ -1975,6 +1975,77 @@ namespace EPPlusTest
 			Assert.AreEqual("E5", excelAddress.Addresses[2].Address);
 		}
 		#endregion
+
+		#region Full Row/Column Tests
+		[TestMethod]
+		public void IsFullColumn()
+		{
+			var address = new ExcelAddress("C:C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("$C:$C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("C:$C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("$C:C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("'Sheet1'!$C:$C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("'Sheet1'!$C:'Sheet1'!$C");
+			Assert.IsTrue(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+		}
+
+		[TestMethod]
+		public void IsFullRowTest()
+		{
+			var address = new ExcelAddress("4:4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+			address = new ExcelAddress("$4:$4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+			address = new ExcelAddress("4:$4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+			address = new ExcelAddress("$4:4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+			address = new ExcelAddress("'Sheet1'!$4:$4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+			address = new ExcelAddress("'Sheet1'!$4:'Sheet1'!$4");
+			Assert.IsTrue(address._isFullRow);
+			Assert.IsFalse(address._isFullColumn);
+		}
+
+		[TestMethod]
+		public void IsFullRowsAndColumnsMultiAddressesAreFalse()
+		{
+			var address = new ExcelAddress("B5");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("B5:C6");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("B5,C:C");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("C:C,B5");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("C:C,B5:D9");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+			address = new ExcelAddress("B5:D9,C:C");
+			Assert.IsFalse(address._isFullColumn);
+			Assert.IsFalse(address._isFullRow);
+		}
+		#endregion
 		#endregion
 
 		#region ExcelFormulaAddress Tests

--- a/EPPlusTest/ExcelCellBaseTest.cs
+++ b/EPPlusTest/ExcelCellBaseTest.cs
@@ -197,7 +197,7 @@ namespace EPPlusTest
 		public void GetRowColFromAddressWithFullyQualifiedEndReference()
 		{
 			var address = "Sheet2!B2:'Sheet2'!C2";
-			var result = ExcelCellBase.GetRowColFromAddress(address, out var fromRow, out var fromCol, out var toRow, out var toCol, out var fromRowFixed, out var fromColFixed, out var toRowFixed, out var toColFixed);
+			var result = ExcelCellBase.GetRowColFromAddress(address, out var fromRow, out var fromCol, out var toRow, out var toCol, out var fromRowFixed, out var fromColFixed, out var toRowFixed, out var toColFixed, out bool hasFullRow, out bool hasFullColumn);
 			Assert.IsTrue(result);
 			Assert.AreEqual(2, fromRow);
 			Assert.AreEqual(2, fromCol);
@@ -207,6 +207,8 @@ namespace EPPlusTest
 			Assert.IsFalse(fromColFixed);
 			Assert.IsFalse(toRowFixed);
 			Assert.IsFalse(toColFixed);
+			Assert.IsFalse(hasFullRow);
+			Assert.IsFalse(hasFullColumn);
 		}
 		#endregion
 	}


### PR DESCRIPTION
Fixed issue where getting relative formula of a named range throw an exception if the named range referred to an entire row or column.