### PR TITLE
Fixed match for null arguments.

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -55,6 +55,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			int? lastValidIndex = null;
 			do
 			{
+				if (navigator.CurrentValue == null && searchedValue == null)
+					return this.CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
 				var matchResult = this.IsMatch(navigator.CurrentValue, searchedValue);
 				// For all match types, if the match result indicated equality, return the index (1 based)
 				if (matchResult == 0)

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
@@ -449,7 +449,41 @@ namespace EPPlusTest.Excel.Functions
 			Assert.AreEqual(1, result.Result);
 		}
 
-		[TestMethod, Ignore]
+		[TestMethod]
+		public void MatchWithNullArgumentsReturnsNotApplicableException()
+		{
+			var func = new Match();
+			var args = FunctionsHelper.CreateArgs("B7", "A1:C1", -1);
+			var parsingContext = ParsingContext.Create();
+			parsingContext.Scopes.NewScope(RangeAddress.Empty);
+			var provider = MockRepository.GenerateStub<ExcelDataProvider>();
+			parsingContext.ExcelDataProvider = provider;
+			var result = func.Execute(args, parsingContext);
+			Assert.IsInstanceOfType(result.Result, typeof(ExcelErrorValue));
+			var errorValue = result.Result as ExcelErrorValue;
+			Assert.AreEqual(eErrorType.NA, errorValue.Type);
+		}
+
+		[TestMethod]
+		public void MatchCannotFindMatchReturnsNotApplicableException()
+		{
+			var func = new Match();
+			var args = FunctionsHelper.CreateArgs("B7", "A1:C1", 0);
+			var parsingContext = ParsingContext.Create();
+			parsingContext.Scopes.NewScope(RangeAddress.Empty);
+			var provider = MockRepository.GenerateStub<ExcelDataProvider>();
+			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(10);
+			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(8);
+			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 3)).Return(5);
+			provider.Stub(x => x.GetCellValue(WorksheetName, 7, 2)).Return(99);
+			parsingContext.ExcelDataProvider = provider;
+			var result = func.Execute(args, parsingContext);
+			Assert.IsInstanceOfType(result.Result, typeof(ExcelErrorValue));
+			var errorValue = result.Result as ExcelErrorValue;
+			Assert.AreEqual(eErrorType.NA, errorValue.Type);
+		}
+
+		[TestMethod]
 		public void MatchShouldHandleAddressOnOtherSheet()
 		{
 			using (var package = new ExcelPackage())


### PR DESCRIPTION
Match should return #N/A if no match is found. 