### PR TITLE
Expression merging

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/ExcelFunction.cs
@@ -424,7 +424,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			}
 			if (ExcelErrorValue.Values.IsErrorValue(result))
 			{
-				return CreateResult(result, DataType.ExcelAddress);
+				return CreateResult(result, DataType.ExcelError);
 			}
 			if (result == null)
 			{

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
@@ -44,16 +44,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		/// <returns>Returns a <see cref="CompileResult"/> containing either the resulting column or an error value.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
-			string rangeAddress = arguments.Count() == 0 ? string.Empty : this.ArgToString(arguments, 0);
-			if (arguments == null || arguments.Count() == 0 || string.IsNullOrEmpty(rangeAddress))
+			var rangeAddress = arguments.Count() == 0 ? null : arguments.ElementAt(0).ValueAsRangeInfo?.Address;
+			if (arguments == null || arguments.Count() == 0 || rangeAddress == null)
 			{
 				return CreateResult(context.Scopes.Current.Address.FromCol, DataType.Integer);
 			}
-			if (!ExcelAddressUtil.IsValidAddress(rangeAddress))
+			if (!ExcelAddressUtil.IsValidAddress(rangeAddress.Address))
 				return new CompileResult(eErrorType.Value);
-			var factory = new RangeAddressFactory(context.ExcelDataProvider);
-			var address = factory.Create(rangeAddress);
-			return CreateResult(address.FromCol, DataType.Integer);
+			return CreateResult(rangeAddress._fromCol, DataType.Integer);
 		}
 		#endregion
 	}

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
@@ -53,7 +53,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		{
 			var searchedValue = arguments.ElementAt(0).Value;
 			Require.That(arguments.ElementAt(1).Value).Named("firstAddress").IsNotNull();
-			var firstAddress = ArgToString(arguments, 1);
+			var firstAddress = arguments.ElementAt(1).ValueAsRangeInfo?.Address.Address;
 			var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
 			var address = rangeAddressFactory.Create(firstAddress);
 			var nRows = address.ToRow - address.FromRow;

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupArguments.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupArguments.cs
@@ -75,7 +75,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 
 			if (indexVal.DataType == DataType.Enumerable)
 			{
-				var rangeInfo = indexVal.Value as IRangeInfo;
+				var rangeInfo = indexVal.ValueAsRangeInfo;
 				var address = rangeInfo?.Address ?? throw new InvalidOperationException("Value does not match declared type.");
 				var indexObj = context.ExcelDataProvider.GetRangeValue(address.WorkSheet ?? context.Scopes.Current.Address.Worksheet, address._fromRow, address._fromCol);
 				LookupIndex = (int)_argumentParsers.GetParser(DataType.Integer).Parse(indexObj);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupArguments.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupArguments.cs
@@ -22,9 +22,11 @@
  *******************************************************************************
  * Mats Alm   		                Added		                2013-12-03
  *******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
+using static OfficeOpenXml.FormulaParsing.ExcelDataProvider;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
@@ -71,15 +73,16 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			}
 			var indexVal = arguments.ElementAt(2);
 
-			if (indexVal.DataType == DataType.ExcelAddress)
+			if (indexVal.DataType == DataType.Enumerable)
 			{
-				var address = new ExcelAddress(indexVal.Value.ToString());
+				var rangeInfo = indexVal.Value as IRangeInfo;
+				var address = rangeInfo?.Address ?? throw new InvalidOperationException("Value does not match declared type.");
 				var indexObj = context.ExcelDataProvider.GetRangeValue(address.WorkSheet ?? context.Scopes.Current.Address.Worksheet, address._fromRow, address._fromCol);
 				LookupIndex = (int)_argumentParsers.GetParser(DataType.Integer).Parse(indexObj);
 			}
 			else
 			{
-				LookupIndex = (int)_argumentParsers.GetParser(DataType.Integer).Parse(arguments.ElementAt(2).Value);
+				LookupIndex = (int)_argumentParsers.GetParser(DataType.Integer).Parse(indexVal.Value);
 			}
 
 			if (arguments.Count() > 3)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -104,7 +104,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 
 		protected ExcelAddress CalculateOffset(FunctionArgument[] arguments, ParsingContext context)
 		{
-			var startRange = ArgToString(arguments, 0);
 			var rowOffset = ArgToInt(arguments, 1);
 			var columnOffset = ArgToInt(arguments, 2);
 			int width = 0, height = 0;
@@ -114,7 +113,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 				width = ArgToInt(arguments, 4);
 			if ((arguments.Length > 3 && height == 0) || (arguments.Length > 4 && width == 0))
 				return null;
-			var address = new ExcelAddress(startRange);
+			var address = arguments[0].ValueAsRangeInfo?.Address;
 			string targetWorksheetName;
 			if (string.IsNullOrEmpty(address.WorkSheet))
 				targetWorksheetName = context.Scopes?.Current?.Address?.Worksheet;

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -45,7 +45,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			if (this.ArgumentsAreValid(arguments, 2, out eErrorType argumentError) == false)
 				return new CompileResult(argumentError);
 			var searchedValue = arguments.ElementAt(0).Value;
-			var address = arguments.ElementAt(1).IsExcelRange ? arguments.ElementAt(1).ValueAsRangeInfo.Address.FullAddress : this.ArgToString(arguments, 1);
+			var address = arguments.ElementAt(1).ValueAsRangeInfo?.Address.Address;
 			var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
 			var rangeAddress = rangeAddressFactory.Create(address);
 			var matchType = this.GetMatchType(arguments);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
@@ -44,16 +44,14 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		/// <returns>Returns a <see cref="CompileResult"/> containing either the resulting row or an error value.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
-			string rangeAddress = arguments.Count() == 0 ? string.Empty : this.ArgToString(arguments, 0);
-			if (arguments == null || arguments.Count() == 0 || string.IsNullOrEmpty(rangeAddress))
+			var rangeAddress = arguments.Count() == 0 ? null : arguments.ElementAt(0).ValueAsRangeInfo?.Address;
+			if (arguments == null || arguments.Count() == 0 || rangeAddress == null)
 			{
 				return CreateResult(context.Scopes.Current.Address.FromRow, DataType.Integer);
 			}
-			if (!ExcelAddressUtil.IsValidAddress(rangeAddress))
+			if (!ExcelAddressUtil.IsValidAddress(rangeAddress.Address))
 				return new CompileResult(eErrorType.Value);
-			var factory = new RangeAddressFactory(context.ExcelDataProvider);
-			var address = factory.Create(rangeAddress);
-			return CreateResult(address.FromRow, DataType.Integer);
+			return CreateResult(rangeAddress._fromRow, DataType.Integer);
 		}
 		#endregion
 	}

--- a/EPPlus/FormulaParsing/ExpressionGraph/CompileStrategy/CompileStrategy.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/CompileStrategy/CompileStrategy.cs
@@ -35,7 +35,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.CompileStrategy
 	{
 		protected readonly Expression _expression;
 
-		public CompileStrategy(Expression expression)
+		protected CompileStrategy(Expression expression)
 		{
 			_expression = expression;
 		}

--- a/EPPlus/FormulaParsing/ExpressionGraph/CompileStrategy/StringConcatStrategy.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/CompileStrategy/StringConcatStrategy.cs
@@ -31,17 +31,28 @@
 
 namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.CompileStrategy
 {
+	/// <summary>
+	/// Performs string concatenation on two expressions.
+	/// </summary>
 	public class StringConcatStrategy : CompileStrategy
 	{
+		#region Constructors
+		/// <summary>
+		/// Creates an instance of a <see cref="StringConcatStrategy"/>.
+		/// </summary>
+		/// <param name="expression">The <see cref="Expression"/> to concatenate.</param>
 		public StringConcatStrategy(Expression expression)
-			 : base(expression)
-		{
+			 : base(expression) { }
+		#endregion
 
-		}
-
+		#region CompileStrategy Overrides
+		/// <summary>
+		/// Concatenates this strategy's expression with the next expression.
+		/// </summary>
+		/// <returns>The merged expression.</returns>
 		public override Expression Compile()
 		{
-			var newExp = _expression is ExcelAddressExpression ? _expression : ExpressionConverter.Instance.ToStringExpression(_expression);
+			var newExp = _expression is ExcelAddressExpression ? _expression : this.CompileToStringExpression(_expression);
 			newExp.Prev = _expression.Prev;
 			newExp.Next = _expression.Next;
 			if (_expression.Prev != null)
@@ -54,5 +65,14 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.CompileStrategy
 			}
 			return newExp.MergeWithNext();
 		}
+		#endregion
+
+		#region Private Methods
+		private StringExpression CompileToStringExpression(Expression expression)
+		{
+			var result = expression.Compile();
+			return new StringExpression(result.Result.ToString()) { Operator = expression.Operator };
+		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/ExpressionGraph/DataType.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/DataType.cs
@@ -40,7 +40,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 		Date,
 		Time,
 		Enumerable,
-		LookupArray,
 		ExcelAddress,
 		ExcelError,
 		Empty,

--- a/EPPlus/FormulaParsing/ExpressionGraph/ExcelAddressExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/ExcelAddressExpression.cs
@@ -76,14 +76,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 
 		public override CompileResult Compile()
 		{
-			if (base.CompileAsExcelAddress)
-				return new CompileResult(this.ExpressionString, DataType.ExcelAddress);
-			else
-				return this.CompileRangeValues();
-		}
-
-		private CompileResult CompileRangeValues()
-		{
 			var c = this._parsingContext.Scopes.Current;
 			var result = _excelDataProvider.GetRange(c.Address.Worksheet, c.Address.FromRow, c.Address.FromCol, this.ExpressionString);
 			if (result == null)
@@ -99,7 +91,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 				return new CompileResult(result, DataType.Enumerable);
 			return CompileSingleCell(result);
 		}
-
+		
 		private CompileResult CompileSingleCell(ExcelDataProvider.IRangeInfo result)
 		{
 			var cell = result.FirstOrDefault();

--- a/EPPlus/FormulaParsing/ExpressionGraph/ExpressionCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/ExpressionCompiler.cs
@@ -46,7 +46,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 
 		}
 
-		public ExpressionCompiler(IExpressionConverter expressionConverter, ICompileStrategyFactory compileStrategyFactory)
+		private ExpressionCompiler(IExpressionConverter expressionConverter, ICompileStrategyFactory compileStrategyFactory)
 		{
 			_expressionConverter = expressionConverter;
 			_compileStrategyFactory = compileStrategyFactory;

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionArgumentExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionArgumentExpression.cs
@@ -40,23 +40,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 		{
 			_function = function;
 		}
-
-		public override bool CompileAsExcelAddress
-		{
-			get
-			{
-				return base.CompileAsExcelAddress;
-			}
-			set
-			{
-				base.CompileAsExcelAddress = value;
-				foreach (var child in Children)
-				{
-					child.CompileAsExcelAddress = value;
-				}
-			}
-		}
-
+		
 		public override bool IsGroupedExpression
 		{
 			get { return false; }

--- a/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ResolveCellReferencesAsRangeCompiler.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/FunctionCompilers/ResolveCellReferencesAsRangeCompiler.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph.FunctionCompilers
 	/// For each of the children of the given function, if that child came from a cell reference,
 	/// this compiler will set that child's ResolveAsRange flag to true.
 	/// </summary>
-	class ResolveCellReferencesAsRangeCompiler : DefaultCompiler
+	public class ResolveCellReferencesAsRangeCompiler : DefaultCompiler
 	{
 		/// <summary>
 		/// Initializes a new ResolveCellReferencesAsRangeCompiler.

--- a/EPPlus/FormulaParsing/ExpressionGraph/IExpressionConverter.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/IExpressionConverter.cs
@@ -33,7 +33,6 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 {
 	public interface IExpressionConverter
 	{
-		StringExpression ToStringExpression(Expression expression);
 		Expression FromCompileResult(CompileResult compileResult);
 	}
 }

--- a/EPPlusTest/FormulaParsing/ExpressionGraph/ExpressionConverterTests.cs
+++ b/EPPlusTest/FormulaParsing/ExpressionGraph/ExpressionConverterTests.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.Globalization;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OfficeOpenXml.FormulaParsing.Excel.Operators;
+using OfficeOpenXml;
+using OfficeOpenXml.FormulaParsing;
 using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 
 namespace EPPlusTest.FormulaParsing.ExpressionGraph
@@ -9,37 +10,9 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph
 	[TestClass]
 	public class ExpressionConverterTests
 	{
-		#region ToStringExpression Tests
-		[TestMethod]
-		public void ToStringExpressionShouldConvertIntegerExpressionToStringExpression()
-		{
-			var integerExpression = new IntegerExpression("2");
-			var result = new ExpressionConverter().ToStringExpression(integerExpression);
-			Assert.IsInstanceOfType(result, typeof(StringExpression));
-			Assert.AreEqual("2", result.Compile().Result);
-		}
-
-		[TestMethod]
-		public void ToStringExpressionShouldCopyOperatorToStringExpression()
-		{
-			var integerExpression = new IntegerExpression("2") { Operator = Operator.Plus };
-			var result = new ExpressionConverter().ToStringExpression(integerExpression);
-			Assert.AreEqual(integerExpression.Operator, result.Operator);
-		}
-
-		[TestMethod]
-		public void ToStringExpressionShouldConvertDecimalExpressionToStringExpression()
-		{
-			var decimalExpression = new DecimalExpression("2.5");
-			var result = new ExpressionConverter().ToStringExpression(decimalExpression);
-			Assert.IsInstanceOfType(result, typeof(StringExpression));
-			Assert.AreEqual($"2{CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator}5", result.Compile().Result);
-		}
-		#endregion
-
 		#region FromCompileResult Tests
 		[TestMethod]
-		public void FromCompileResultShouldCreateIntegerExpressionIfCompileResultIsInteger()
+		public void FromCompileResultInteger()
 		{
 			var compileResult = new CompileResult(1, DataType.Integer);
 			var result = new ExpressionConverter().FromCompileResult(compileResult);
@@ -48,7 +21,69 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph
 		}
 
 		[TestMethod]
-		public void FromCompileResultShouldCreateStringExpressionIfCompileResultIsString()
+		public void FromCompileResultIntegerString()
+		{
+			var compileResult = new CompileResult("1", DataType.Integer);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(1d, result.Compile().Result);
+		}
+		[TestMethod]
+		public void FromCompileResultIntegerUnknown()
+		{
+			var compileResult = new CompileResult(1, DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(1d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultTime()
+		{
+			var compileResult = new CompileResult(1000, DataType.Time);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
+			Assert.AreEqual(1000d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultTimeString()
+		{
+			var compileResult = new CompileResult("1000", DataType.Time);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
+			Assert.AreEqual(1000d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDecimal()
+		{
+			var compileResult = new CompileResult(2.5, DataType.Decimal);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
+			Assert.AreEqual(2.5d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDecimalString()
+		{
+			var compileResult = new CompileResult("2.5", DataType.Decimal);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
+			Assert.AreEqual(2.5d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDecimalUnknown()
+		{
+			var compileResult = new CompileResult(2.5, DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
+			Assert.AreEqual(2.5d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultString()
 		{
 			var compileResult = new CompileResult("abc", DataType.String);
 			var result = new ExpressionConverter().FromCompileResult(compileResult);
@@ -57,32 +92,219 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph
 		}
 
 		[TestMethod]
-		public void FromCompileResultShouldCreateDecimalExpressionIfCompileResultIsDouble()
+		public void FromCompileResultStringFromNumber()
 		{
-			var compileResult = new CompileResult(2.5d, DataType.Decimal);
+			var compileResult = new CompileResult(1000, DataType.String);
 			var result = new ExpressionConverter().FromCompileResult(compileResult);
-			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
-			Assert.AreEqual(2.5d, result.Compile().Result);
+			Assert.IsInstanceOfType(result, typeof(StringExpression));
+			Assert.AreEqual("1000", result.Compile().Result);
 		}
 
 		[TestMethod]
-		public void FromCompileResultShouldCreateDecimalExpressionIfCompileResultIsDecimal()
+		public void FromCompileResultStringUnknown()
 		{
-			decimal input = 2.5m;
-			double expected = Convert.ToDouble(input);
-			var compileResult = new CompileResult(input, DataType.Decimal);
+			var compileResult = new CompileResult("abc", DataType.Unknown);
 			var result = new ExpressionConverter().FromCompileResult(compileResult);
-			Assert.IsInstanceOfType(result, typeof(DecimalExpression));
-			Assert.AreEqual(expected, result.Compile().Result);
+			Assert.IsInstanceOfType(result, typeof(StringExpression));
+			Assert.AreEqual("abc", result.Compile().Result);
 		}
 
 		[TestMethod]
-		public void FromCompileResultShouldCreateBooleanExpressionIfCompileResultIsBoolean()
+		public void FromCompileResultBoolean()
 		{
-			var compileResult = new CompileResult("true", DataType.Boolean);
+			var compileResult = new CompileResult(true, DataType.Boolean);
 			var result = new ExpressionConverter().FromCompileResult(compileResult);
 			Assert.IsInstanceOfType(result, typeof(BooleanExpression));
-			Assert.IsTrue((bool)result.Compile().Result);
+			Assert.AreEqual(true, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultBooleanString()
+		{
+			var compileResult = new CompileResult("false", DataType.Boolean);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(BooleanExpression));
+			Assert.AreEqual(false, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultBooleanUnknown()
+		{
+			var compileResult = new CompileResult(true, DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(BooleanExpression));
+			Assert.AreEqual(true, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDate()
+		{
+			var compileResult = new CompileResult(DateTime.Parse("1/1/2018"), DataType.Date);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DateExpression));
+			Assert.AreEqual(DateTime.Parse("1/1/2018"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDateString()
+		{
+			var compileResult = new CompileResult("1/1/2018", DataType.Date);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DateExpression));
+			Assert.AreEqual(DateTime.Parse("1/1/2018"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDateOADate()
+		{
+			var compileResult = new CompileResult(12345, DataType.Date);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DateExpression));
+			Assert.AreEqual(DateTime.Parse("10/18/1933"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDateOADateString()
+		{
+			var compileResult = new CompileResult("12345", DataType.Date);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DateExpression));
+			Assert.AreEqual(DateTime.Parse("10/18/1933"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultDateUnknown()
+		{
+			var compileResult = new CompileResult(DateTime.Parse("1/1/2018"), DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(DateExpression));
+			Assert.AreEqual(DateTime.Parse("1/1/2018"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultExcelError()
+		{
+			var compileResult = new CompileResult(ExcelErrorValue.Parse("#N/A"), DataType.ExcelError);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(ExcelErrorExpression));
+			Assert.AreEqual(ExcelErrorValue.Parse("#N/A"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultExcelErrorString()
+		{
+			var compileResult = new CompileResult("#NAME?", DataType.ExcelError);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(ExcelErrorExpression));
+			Assert.AreEqual(ExcelErrorValue.Parse("#NAME?"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultExcelErrorUnknown()
+		{
+			var compileResult = new CompileResult(ExcelErrorValue.Parse("#N/A"), DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(ExcelErrorExpression));
+			Assert.AreEqual(ExcelErrorValue.Parse("#N/A"), result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultEmpty()
+		{
+			var compileResult = new CompileResult("whatever", DataType.Empty);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(0d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultEmptyUnknown()
+		{
+			var compileResult = new CompileResult(null, DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(0d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultExcelAddress()
+		{
+			var compileResult = new CompileResult("Sheet1!C3", DataType.ExcelAddress);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(StringExpression));
+			Assert.AreEqual("Sheet1!C3", result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultEnumerableInteger()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet = package.Workbook.Worksheets.Add("Sheet1");
+				sheet.Cells["C1"].Value = 1;
+				sheet.Cells["C2"].Value = 2;
+				sheet.Cells["C3"].Value = 3;
+				var dataProvider = new EpplusExcelDataProvider(package);
+				var range = dataProvider.GetRange("Sheet1", 1, 3, 3, 3);
+				var compileResult = new CompileResult(range, DataType.Enumerable);
+				var result = new ExpressionConverter().FromCompileResult(compileResult);
+				Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+				Assert.AreEqual(1d, result.Compile().Result);
+			}
+		}
+
+		[TestMethod]
+		public void FromCompileResultEnumerableString()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet = package.Workbook.Worksheets.Add("Sheet1");
+				sheet.Cells["C1"].Value = "1";
+				sheet.Cells["C2"].Value = "2";
+				sheet.Cells["C3"].Value = "3";
+				var dataProvider = new EpplusExcelDataProvider(package);
+				var range = dataProvider.GetRange("Sheet1", 1, 3, 3, 3);
+				var compileResult = new CompileResult(range, DataType.Enumerable);
+				var result = new ExpressionConverter().FromCompileResult(compileResult);
+				Assert.IsInstanceOfType(result, typeof(StringExpression));
+				Assert.AreEqual("1", result.Compile().Result);
+			}
+		}
+
+		[TestMethod]
+		public void FromCompileResultEnumerableIntegerUnknown()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var sheet = package.Workbook.Worksheets.Add("Sheet1");
+				sheet.Cells["C1"].Value = 1;
+				sheet.Cells["C2"].Value = 2;
+				sheet.Cells["C3"].Value = 3;
+				var dataProvider = new EpplusExcelDataProvider(package);
+				var range = dataProvider.GetRange("Sheet1", 1, 3, 3, 3);
+				var compileResult = new CompileResult(range, DataType.Unknown);
+				var result = new ExpressionConverter().FromCompileResult(compileResult);
+				Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+				Assert.AreEqual(1d, result.Compile().Result);
+			}
+		}
+
+		[TestMethod]
+		public void FromCompileResultEnumerableList()
+		{
+			var compileResult = new CompileResult(new List<object> { 1, 2, 3 }, DataType.Enumerable);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(1d, result.Compile().Result);
+		}
+
+		[TestMethod]
+		public void FromCompileResultEnumerableListUnknown()
+		{
+			var compileResult = new CompileResult(new List<object> { 1, 2, 3 }, DataType.Unknown);
+			var result = new ExpressionConverter().FromCompileResult(compileResult);
+			Assert.IsInstanceOfType(result, typeof(IntegerExpression));
+			Assert.AreEqual(1d, result.Compile().Result);
 		}
 		#endregion
 	}

--- a/EPPlusTest/FormulaParsing/ExpressionGraph/ExpressionGraphBuilderTests.cs
+++ b/EPPlusTest/FormulaParsing/ExpressionGraph/ExpressionGraphBuilderTests.cs
@@ -240,7 +240,7 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph
 			var expression = _graphBuilder.Build(tokens);
 			Assert.AreEqual(1, expression.Expressions.Count());
 
-			var compiler = new ExpressionCompiler(new ExpressionConverter(), new CompileStrategyFactory());
+			var compiler = new ExpressionCompiler();
 			var result = compiler.Compile(expression.Expressions);
 			Assert.AreEqual("Yes", result.Result);
 		}

--- a/EPPlusTest/FormulaParsing/ExpressionGraph/FunctionCompilers/LookupFunctionCompilerTest.cs
+++ b/EPPlusTest/FormulaParsing/ExpressionGraph/FunctionCompilers/LookupFunctionCompilerTest.cs
@@ -15,25 +15,18 @@ namespace EPPlusTest.FormulaParsing.ExpressionGraph.FunctionCompilers
 		[TestMethod]
 		public void VLookupCompiler()
 		{
-			var parsingContext = ParsingContext.Create();
-			parsingContext.Scopes.NewScope(RangeAddress.Empty);
 			using (var excelPackage = new ExcelPackage())
 			{
 				var worksheet = excelPackage.Workbook.Worksheets.Add("Sheet1");
 				worksheet.Cells["C7"].Value = 1;
 				worksheet.Cells["C8"].Value = 2;
-				var provider = MockRepository.GenerateStub<EpplusExcelDataProvider>(excelPackage);
-				provider.Stub(x => x.GetCellValue(null, 1, 1)).Return(1);
-				provider.Stub(x => x.GetCellValue(null, 1, 2)).Return(1);
-				provider.Stub(x => x.GetCellValue(null, 2, 1)).Return(2);
-				provider.Stub(x => x.GetCellValue(null, 2, 2)).Return(5);
-				provider.Stub(x => x.GetRange(null, 0, 0, "C8")).Return(new RangeInfo(worksheet, 8, 3, 8, 3));
-				provider.Stub(x => x.GetRange(null, 0, 0, "C7")).Return(new RangeInfo(worksheet, 7, 3, 7, 3));
-				parsingContext.ExcelDataProvider = provider;
-				var tokens = SourceCodeTokenizer.Default.Tokenize("VLOOKUP(C8, A1:B2, C7 + 1)", worksheet.Name);
-				var graph = new ExpressionGraphBuilder(provider, parsingContext).Build(tokens);
-				var compileResult = new ExpressionCompiler().Compile(graph.Expressions);
-				Assert.AreEqual(5, compileResult.ResultValue);
+				worksheet.Cells["A1"].Value = 1;
+				worksheet.Cells["B1"].Value = 1;
+				worksheet.Cells["A2"].Value = 2;
+				worksheet.Cells["B2"].Value = 5;
+				worksheet.Cells["C3"].Formula = "VLOOKUP(C8, A1:B2, C7 + 1)";
+				worksheet.Cells["C3"].Calculate();
+				Assert.AreEqual(5, worksheet.Cells["C3"].Value);
 			}
 		}
 	}

--- a/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/IntegrationTests/BuiltInFunctions/RefAndLookupTests.cs
@@ -130,13 +130,13 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		[TestMethod]
 		public void HLookupShouldReturnClosestValueBelowIfLastArgIsTrue()
 		{
-			var lookupAddress = "A1:B2";
-			_excelDataProvider.Stub(x => x.GetDimensionEnd(Arg<string>.Is.Anything)).Return(new ExcelCellAddress(5, 5));
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(3);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(5);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 2, 1)).Return(1);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 2, 2)).Return(2);
-			var result = _parser.Parse("HLOOKUP(4, " + lookupAddress + ", 2, true)");
+			_worksheet.Cells["A1"].Value = 3;
+			_worksheet.Cells["B1"].Value = 5;
+			_worksheet.Cells["A2"].Value = 1;
+			_worksheet.Cells["B2"].Value = 2;
+			_worksheet.Cells["A3"].Formula = "HLOOKUP(4, A1:B2, 2, TRUE)";
+			_worksheet.Calculate();
+			var result = _worksheet.Cells["A3"].Value;
 			Assert.AreEqual(1, result);
 		}
 
@@ -165,12 +165,13 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		[TestMethod]
 		public void LookupShouldReturnMatchingValue()
 		{
-			var lookupAddress = "A1:B2";
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(3);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(5);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 2, 1)).Return(4);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 2, 2)).Return(1);
-			var result = _parser.Parse("LOOKUP(4, " + lookupAddress + ")");
+			_worksheet.Cells["A1"].Value = 3;
+			_worksheet.Cells["B1"].Value = 5;
+			_worksheet.Cells["A2"].Value = 4;
+			_worksheet.Cells["B2"].Value = 1;
+			_worksheet.Cells["A3"].Formula = "LOOKUP(4, A1:B2)";
+			_worksheet.Calculate();
+			var result = _worksheet.Cells["A3"].Value;
 			Assert.AreEqual(1, result);
 		}
 		#endregion
@@ -271,9 +272,13 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		[TestMethod]
 		public void RowsShouldReturnNbrOfRows()
 		{
-			_excelDataProvider.Stub(x => x.GetRangeFormula("", 4, 1)).Return("Rows(A5:B7)");
-			var result = _parser.ParseAt("A4");
-			Assert.AreEqual(3, result);
+			using (var package = new ExcelPackage())
+			{
+				var s1 = package.Workbook.Worksheets.Add("test");
+				s1.Cells["A4"].Formula = "Rows(A5:B7)";
+				s1.Calculate();
+				Assert.AreEqual(3, s1.Cells["A4"].Value);
+			}
 		}
 		#endregion
 
@@ -281,9 +286,13 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		[TestMethod]
 		public void ColumnsShouldReturnNbrOfCols()
 		{
-			_excelDataProvider.Stub(x => x.GetRangeFormula("", 4, 1)).Return("Columns(A5:B7)");
-			var result = _parser.ParseAt("A4");
-			Assert.AreEqual(2, result);
+			using (var package = new ExcelPackage())
+			{
+				var s1 = package.Workbook.Worksheets.Add("test");
+				s1.Cells["A4"].Formula = "Columns(A5:B7)";
+				s1.Calculate();
+				Assert.AreEqual(2, s1.Cells["A4"].Value);
+			}
 		}
 		#endregion
 
@@ -582,10 +591,11 @@ namespace EPPlusTest.FormulaParsing.IntegrationTests.BuiltInFunctions
 		[TestMethod]
 		public void MatchShouldReturnIndexOfMatchingValue()
 		{
-			var lookupAddress = "A1:A2";
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(3);
-			_excelDataProvider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(5);
-			var result = _parser.Parse("MATCH(3, " + lookupAddress + ")");
+			_worksheet.Cells["A1"].Value = 3;
+			_worksheet.Cells["A2"].Value = 3;
+			_worksheet.Cells["A3"].Formula = "MATCH(3, A1:A2)";
+			_worksheet.Calculate();
+			var result = _worksheet.Cells["A3"].Value;
 			Assert.AreEqual(1, result);
 		}
 


### PR DESCRIPTION
Cleaned up some expression compilation to get more consistent matches between actual result types and declared result types in order to better convert CompileResults back into Expressions for Operator merging.