### PR TITLE
SourceCodeTokenizer Would Get Greedy For Strings With Brackets

### DIFF
--- a/EPPlus/FormulaParsing/LexicalAnalysis/TokenSeparatorHandlers/BracketHandler.cs
+++ b/EPPlus/FormulaParsing/LexicalAnalysis/TokenSeparatorHandlers/BracketHandler.cs
@@ -35,6 +35,8 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis.TokenSeparatorHandlers
 	{
 		public override bool Handle(char c, Token tokenSeparator, TokenizerContext context, ITokenIndexProvider tokenIndexProvider)
 		{
+			if (context.IsInString)
+				return false;
 			if (tokenSeparator.TokenType == TokenType.OpeningBracket)
 			{
 				context.AppendToCurrentToken(c);

--- a/EPPlusTest/Calculation.cs
+++ b/EPPlusTest/Calculation.cs
@@ -265,6 +265,18 @@ namespace EPPlusTest
 				Assert.AreEqual(ExcelErrorValue.Create(eErrorType.Value), sheet.Cells[2, 2].Value);
 			}
 		}
+
+		[TestMethod]
+		public void CalculateHandlesNestedBrackets()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var worksheet = package.Workbook.Worksheets.Add("sheet");
+				worksheet.Cells["C3"].Formula = "=\"\"\"[Cust - Bill-to].[b\"&\"y Country City].[Country]\"\"\"";
+				worksheet.Cells["C3"].Calculate();
+				Assert.AreEqual("\"[Cust - Bill-to].[by Country City].[Country]\"", worksheet.Cells["C3"].Value);
+			}
+		}
 		#endregion
 
 		#region Private Methods


### PR DESCRIPTION
If there was string concatenated string content where an earlier string fragment contained a bracket, that would upset the depth count and cause all the concatenated strings to be treated as a single string. This caused StringContent to effectively contain formulas after tokenization.