### PR TITLE
19/bugs/7789 lookup function fix

### DIFF
--- a/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/BuiltInFunctions.cs
@@ -172,20 +172,20 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions
 			this.Functions["false"] = new False();
 			// Reference and lookup
 			this.Functions["address"] = new Address();
-			this.Functions["hlookup"] = new HLookup { LookupArgumentIndicies = new List<int> { 1 } };
-			this.Functions["vlookup"] = new VLookup { LookupArgumentIndicies = new List<int> { 1 } };
-			this.Functions["lookup"] = new Lookup { LookupArgumentIndicies = new List<int> { 1, 2 } };
-			this.Functions["match"] = new Match { LookupArgumentIndicies = new List<int> { 1 } };
-			this.Functions["row"] = new Row() { LookupArgumentIndicies = new List<int> { 0 } };
-			this.Functions["rows"] = new Rows() { LookupArgumentIndicies = new List<int> { 0 } };
-			this.Functions["column"] = new Column() { LookupArgumentIndicies = new List<int> { 0 } };
-			this.Functions["columns"] = new Columns() { LookupArgumentIndicies = new List<int> { 0 } };
+			this.Functions["hlookup"] = new HLookup();
+			this.Functions["vlookup"] = new VLookup();
+			this.Functions["lookup"] = new Lookup();
+			this.Functions["match"] = new Match();
+			this.Functions["row"] = new Row();
+			this.Functions["rows"] = new Rows();
+			this.Functions["column"] = new Column();
+			this.Functions["columns"] = new Columns();
 			this.Functions["choose"] = new Choose();
 			this.Functions["index"] = new Index();
 			this.Functions["indirect"] = new Indirect();
 			this.Functions["indirectaddress"] = new IndirectAddress();
-			this.Functions["offset"] = new Offset() { LookupArgumentIndicies = new List<int> { 0 } };
-			this.Functions["offsetaddress"] = new OffsetAddress() { LookupArgumentIndicies = new List<int> { 0 } };
+			this.Functions["offset"] = new Offset();
+			this.Functions["offsetaddress"] = new OffsetAddress();
 			// Date
 			this.Functions["date"] = new Date();
 			this.Functions["today"] = new Today();

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
@@ -35,6 +35,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	public class Column : LookupFunction
 	{
 		#region LookupFunction Members
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 		#endregion
 

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Column.cs
@@ -22,7 +22,6 @@
  *******************************************************************************
  * Mats Alm   		                Added		                2013-12-03
  *******************************************************************************/
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OfficeOpenXml.FormulaParsing.ExcelUtilities;
@@ -35,6 +34,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	/// </summary>
 	public class Column : LookupFunction
 	{
+		#region LookupFunction Members
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
+
 		#region Public ExcelFunction overrides
 		/// <summary>
 		/// Calculates the column of either the given range or the column that the function is executed in.

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
@@ -32,6 +32,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Columns : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
@@ -32,6 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Columns : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 1, out eErrorType argumentError) == false)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Columns.cs
@@ -32,12 +32,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Columns : LookupFunction
 	{
+		#region LookupFunction Overrides
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>The <see cref="CompileResult"/>.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 1, out eErrorType argumentError) == false)
@@ -59,5 +68,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			}
 			throw new ArgumentException("Invalid range supplied");
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
@@ -31,12 +31,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class HLookup : LookupFunction
 	{
+		#region LookupFunction Overrides
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>The <see cref="CompileResult"/>.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 3, out eErrorType argumentError) == false)
@@ -50,5 +59,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			else 
 				return Lookup(navigator, lookupArgs, new LookupValueMatcher());
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
@@ -31,6 +31,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class HLookup : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/HLookup.cs
@@ -31,6 +31,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class HLookup : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 3, out eErrorType argumentError) == false)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
@@ -32,6 +32,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Lookup : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1, 2 };
 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
@@ -32,12 +32,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Lookup : LookupFunction
 	{
+		#region LookupFunction Overrides
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1, 2 };
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>The <see cref="CompileResult"/>.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 2, out eErrorType argumentError) == false)
@@ -46,7 +55,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 				return this.HandleTwoRanges(arguments, context);
 			return this.HandleSingleRange(arguments, context);
 		}
+		#endregion
 
+		#region Private Methods
 		private bool HaveTwoRanges(IEnumerable<FunctionArgument> arguments)
 		{
 			if (arguments.Count() == 2) return false;
@@ -96,5 +107,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			var navigator = LookupNavigatorFactory.Create(lookupDirection, lookupArgs, context);
 			return Lookup(navigator, lookupArgs, new LookupValueMatcher());
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Lookup.cs
@@ -32,21 +32,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Lookup : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1, 2 };
+
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 2, out eErrorType argumentError) == false)
 				return new CompileResult(argumentError);
-			if (HaveTwoRanges(arguments))
-			{
-				return HandleTwoRanges(arguments, context);
-			}
-			return HandleSingleRange(arguments, context);
+			if (this.HaveTwoRanges(arguments))
+				return this.HandleTwoRanges(arguments, context);
+			return this.HandleSingleRange(arguments, context);
 		}
 
 		private bool HaveTwoRanges(IEnumerable<FunctionArgument> arguments)
 		{
 			if (arguments.Count() == 2) return false;
-			return (ExcelAddressUtil.IsValidAddress(arguments.ElementAt(2).Value.ToString()));
+			return arguments.ElementAt(2).IsExcelRange;
 		}
 
 		private CompileResult HandleSingleRange(IEnumerable<FunctionArgument> arguments, ParsingContext context)
@@ -75,8 +75,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			var searchedValue = arguments.ElementAt(0).Value;
 			Require.That(arguments.ElementAt(1).Value).Named("firstAddress").IsNotNull();
 			Require.That(arguments.ElementAt(2).Value).Named("secondAddress").IsNotNull();
-			var firstAddress = ArgToString(arguments, 1);
-			var secondAddress = ArgToString(arguments, 2);
+			var firstAddress = arguments.ElementAt(1).ValueAsRangeInfo?.Address.Address;
+			var secondAddress = arguments.ElementAt(2).ValueAsRangeInfo?.Address.Address;
 			var rangeAddressFactory = new RangeAddressFactory(context.ExcelDataProvider);
 			var address1 = rangeAddressFactory.Create(firstAddress);
 			var address2 = rangeAddressFactory.Create(secondAddress);

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -60,11 +60,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 					if (lastValue != null && navigator.CurrentValue == null) break;
 
 					if (!lookupArgs.RangeLookup) continue;
-					if (lastValue == null && matchResult == -1)
+					if (lastValue == null && matchResult < 0)
 					{
 						return new CompileResult(eErrorType.NA);
 					}
-					if (lastValue != null && matchResult == -1 && lastMatchResult == 1)
+					if (lastValue != null && matchResult < 0 && lastMatchResult > 0)
 					{
 						return new CompileResultFactory().Create(lastLookupValue);
 					}

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -31,7 +31,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	public abstract class LookupFunction : ExcelFunction
 	{
 		/// <summary>
-		/// Gets or sets a value representing the indicies of the arguments to the lookup function that
+		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public abstract List<int> LookupArgumentIndicies { get; }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -28,14 +28,20 @@ using OfficeOpenXml.FormulaParsing.ExpressionGraph;
 
 namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
+	/// <summary>
+	/// The base class for "lookup" type excel functions
+	/// </summary>
 	public abstract class LookupFunction : ExcelFunction
 	{
+		#region Abstract Properties
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public abstract List<int> LookupArgumentIndicies { get; }
+		#endregion
 
+		#region Protected Methods
 		protected LookupDirection GetLookupDirection(RangeAddress rangeAddress)
 		{
 			var nRows = rangeAddress.ToRow - rangeAddress.FromRow;
@@ -105,5 +111,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			var toCol = (width == 0 ? address._toCol : width + address._fromCol - 1) + columnOffset;
 			return new ExcelAddress(targetWorksheetName, fromRow, fromCol, toRow, toCol);
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/LookupFunction.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		/// Gets or sets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
-		public List<int> LookupArgumentIndicies { get; set; }
+		public abstract List<int> LookupArgumentIndicies { get; }
 
 		protected LookupDirection GetLookupDirection(RangeAddress rangeAddress)
 		{
@@ -60,11 +60,11 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 					if (lastValue != null && navigator.CurrentValue == null) break;
 
 					if (!lookupArgs.RangeLookup) continue;
-					if (lastValue == null && matchResult < 0)
+					if (lastValue == null && matchResult == -1)
 					{
 						return new CompileResult(eErrorType.NA);
 					}
-					if (lastValue != null && matchResult < 0 && lastMatchResult > 0)
+					if (lastValue != null && matchResult == -1 && lastMatchResult == 1)
 					{
 						return new CompileResultFactory().Create(lastLookupValue);
 					}

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -31,6 +31,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Match : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
 
 		private enum MatchType

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -57,7 +57,7 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			{
 				if (navigator.CurrentValue == null && searchedValue == null)
 					return this.CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
-				int matchResult;
+				int? matchResult;
 				if (matchType == MatchType.ExactMatch)
 					matchResult = new WildCardValueMatcher().IsMatch(searchedValue, navigator.CurrentValue);
 				else

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -31,19 +31,30 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Match : LookupFunction
 	{
+		#region LookupFunction Members
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+		#endregion
 
+		#region Enums
 		private enum MatchType
 		{
 			ClosestAbove = -1,
 			ExactMatch = 0,
 			ClosestBelow = 1
 		}
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>An address range <see cref="CompileResult"/> if successful, otherwise an error result.</returns> 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 2, out eErrorType argumentError) == false)
@@ -80,7 +91,9 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 				return this.CreateResult(ExcelErrorValue.Create(eErrorType.NA), DataType.ExcelError);
 			return this.CreateResult(lastValidIndex, DataType.Integer);
 		}
+		#endregion
 
+		#region Private Methods
 		private MatchType GetMatchType(IEnumerable<FunctionArgument> arguments)
 		{
 			var matchType = MatchType.ClosestBelow;
@@ -88,5 +101,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 				matchType = (MatchType)this.ArgToInt(arguments, 2);
 			return matchType;
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Match.cs
@@ -31,6 +31,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Match : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+
 		private enum MatchType
 		{
 			ClosestAbove = -1,

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
@@ -41,6 +41,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		#endregion
 
 		#region LookupFunction Members
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 		#endregion
 

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Offset.cs
@@ -40,6 +40,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		public const string Name = "OFFSET";
 		#endregion
 
+		#region LookupFunction Members
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
+
 		#region Public LookupFunction Overrides
 		/// <summary>
 		/// Executes the OFFSET function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
@@ -41,6 +41,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		public const string Name = "OFFSETADDRESS";
 		#endregion
 
+		#region LookupFunction Members
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
+
 		#region ExcelFunction Overrides
 		/// <summary>
 		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/OffsetAddress.cs
@@ -42,6 +42,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 		#endregion
 
 		#region LookupFunction Members
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 		#endregion
 

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
@@ -35,6 +35,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	/// </summary>
 	public class Row : LookupFunction
 	{
+		#region LookupFunction Members
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
+
 		#region Public ExcelFunction overrides
 		/// <summary>
 		/// Calculates the row of either the given range or the column that the function is executed in.

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Row.cs
@@ -36,6 +36,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 	public class Row : LookupFunction
 	{
 		#region LookupFunction Members
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 		#endregion
 

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
@@ -32,12 +32,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Rows : LookupFunction
 	{
+		#region LookupFunction Overrides
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>The <see cref="CompileResult"/>.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 1, out eErrorType argumentError) == false)
@@ -59,5 +68,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			}
 			throw new ArgumentException("Invalid range supplied");
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
@@ -32,6 +32,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Rows : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/Rows.cs
@@ -32,6 +32,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class Rows : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 0 };
+
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 1, out eErrorType argumentError) == false)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
@@ -31,12 +31,21 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class VLookup : LookupFunction
 	{
+		#region LookupFunction Overrides
 		/// <summary>
 		/// Gets a value representing the indicies of the arguments to the lookup function that
 		/// should be compiled as ExcelAddresses instead of being evaluated.
 		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+		#endregion
 
+		#region ExcelFunction Overrides
+		/// <summary>
+		/// Executes the function with the specified <paramref name="arguments"/> in the specified <paramref name="context"/>.
+		/// </summary>
+		/// <param name="arguments">The arguments with which to evaluate the function.</param>
+		/// <param name="context">The context in which to evaluate the function.</param>
+		/// <returns>The <see cref="CompileResult"/>.</returns>
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 3, out eErrorType argumentError) == false)
@@ -48,5 +57,6 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 			else
 				return Lookup(navigator, lookupArgs, new LookupValueMatcher());
 		}
+		#endregion
 	}
 }

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
@@ -31,6 +31,8 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class VLookup : LookupFunction
 	{
+		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
+
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
 		{
 			if (this.ArgumentsAreValid(arguments, 3, out eErrorType argumentError) == false)

--- a/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
+++ b/EPPlus/FormulaParsing/Excel/Functions/RefAndLookup/VLookup.cs
@@ -31,6 +31,10 @@ namespace OfficeOpenXml.FormulaParsing.Excel.Functions.RefAndLookup
 {
 	public class VLookup : LookupFunction
 	{
+		/// <summary>
+		/// Gets a value representing the indicies of the arguments to the lookup function that
+		/// should be compiled as ExcelAddresses instead of being evaluated.
+		/// </summary>
 		public override List<int> LookupArgumentIndicies { get; } = new List<int> { 1 };
 
 		public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)

--- a/EPPlus/FormulaParsing/ExcelUtilities/LookupValueMatcher.cs
+++ b/EPPlus/FormulaParsing/ExcelUtilities/LookupValueMatcher.cs
@@ -2,9 +2,9 @@
 {
 	public class LookupValueMatcher : ValueMatcher
 	{
-		protected override int CompareObjectToString(object o1, string o2)
+		protected override int? CompareObjectToString(object o1, string o2)
 		{
-			return IncompatibleOperands;
+			return null;
 		}
 	}
 }

--- a/EPPlus/FormulaParsing/ExcelUtilities/WildCardValueMatcher.cs
+++ b/EPPlus/FormulaParsing/ExcelUtilities/WildCardValueMatcher.cs
@@ -34,7 +34,7 @@ namespace OfficeOpenXml.FormulaParsing.ExcelUtilities
 {
 	public class WildCardValueMatcher : ValueMatcher
 	{
-		protected override int CompareStringToString(string searchString, string testValue)
+		protected override int? CompareStringToString(string searchString, string testValue)
 		{
 			if (searchString.Contains("*") || searchString.Contains("?") || searchString.Contains("~"))
 			{

--- a/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
+++ b/EPPlusTest/FormulaParsing/Excel/Functions/RefAndLookup/RefAndLookupTests.cs
@@ -307,43 +307,57 @@ namespace EPPlusTest.Excel.Functions
 		[TestMethod]
 		public void LookupShouldReturnResultFromMatchingSecondArrayHorizontal()
 		{
-			var func = new Lookup();
-			var args = FunctionsHelper.CreateArgs(4, "A1:C1", "A3:C3");
-			var parsingContext = ParsingContext.Create();
-			parsingContext.Scopes.NewScope(RangeAddress.Empty);
-
-			var provider = MockRepository.GenerateStub<ExcelDataProvider>();
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(1);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(3);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 3)).Return(5);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 1)).Return("A");
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 2)).Return("B");
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 3)).Return("C");
-
-			parsingContext.ExcelDataProvider = provider;
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual("B", result.Result);
+			using (var package = new ExcelPackage())
+			{
+				var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+				worksheet.Cells[1, 1].Value = 1;
+				worksheet.Cells[1, 2].Value = 3;
+				worksheet.Cells[1, 3].Value = 5;
+				worksheet.Cells[3, 1].Value = "A";
+				worksheet.Cells[3, 2].Value = "B";
+				worksheet.Cells[3, 3].Value = "C";
+				worksheet.Cells[5, 5].Formula = "=LOOKUP(4, A1:C1, A3:C3)";
+				worksheet.Calculate();
+				Assert.AreEqual("B", worksheet.Cells[5, 5].Value);
+			}
 		}
 
 		[TestMethod]
 		public void LookupShouldReturnResultFromMatchingSecondArrayHorizontalWithOffset()
 		{
-			var func = new Lookup();
-			var args = FunctionsHelper.CreateArgs(4, "A1:C1", "B3:D3");
-			var parsingContext = ParsingContext.Create();
-			parsingContext.Scopes.NewScope(RangeAddress.Empty);
+			using (var package = new ExcelPackage())
+			{
+				var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+				worksheet.Cells[1, 1].Value = 1;
+				worksheet.Cells[1, 2].Value = 3;
+				worksheet.Cells[1, 3].Value = 5;
+				worksheet.Cells[3, 2].Value = "A";
+				worksheet.Cells[3, 3].Value = "B";
+				worksheet.Cells[3, 4].Value = "C";
+				worksheet.Cells[5, 5].Formula = "=LOOKUP(4, A1:C1, B3:D3)";
+				worksheet.Calculate();
+				Assert.AreEqual("B", worksheet.Cells[5, 5].Value);
+			}
+		}
 
-			var provider = MockRepository.GenerateStub<ExcelDataProvider>();
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 1)).Return(1);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 2)).Return(3);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 1, 3)).Return(5);
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 2)).Return("A");
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 3)).Return("B");
-			provider.Stub(x => x.GetCellValue(WorksheetName, 3, 4)).Return("C");
-
-			parsingContext.ExcelDataProvider = provider;
-			var result = func.Execute(args, parsingContext);
-			Assert.AreEqual("B", result.Result);
+		[TestMethod]
+		public void LookupWithIncompatibleType()
+		{
+			using (var package = new ExcelPackage())
+			{
+				var worksheet = package.Workbook.Worksheets.Add("Sheet1");
+				worksheet.Cells[1, 1].Value = "A";
+				worksheet.Cells[1, 2].Value = 1;
+				worksheet.Cells[1, 3].Value = 2;
+				worksheet.Cells[1, 4].Value = 3;
+				worksheet.Cells[3, 1].Value = "A";
+				worksheet.Cells[3, 2].Value = "B";
+				worksheet.Cells[3, 3].Value = "C";
+				worksheet.Cells[3, 4].Value = "D";
+				worksheet.Cells[5, 5].Formula = "=LOOKUP(2, A1:D1, A3:D3)";
+				worksheet.Calculate();
+				Assert.AreEqual("C", worksheet.Cells[5, 5].Value);
+			}
 		}
 
 		[TestMethod]

--- a/EPPlusTest/FormulaParsing/ExcelUtilities/ValueMatcherTests.cs
+++ b/EPPlusTest/FormulaParsing/ExcelUtilities/ValueMatcherTests.cs
@@ -93,12 +93,12 @@ namespace EPPlusTest.ExcelUtilities
 		}
 
 		[TestMethod]
-		public void ShouldReturnMînus2WhenTypesDifferAndStringConversionToDoubleFails()
+		public void ShouldReturnNullWhenTypesDifferAndStringConversionToDoubleFails()
 		{
 			object o1 = 2d;
 			object o2 = "T";
 			var result = _matcher.IsMatch(o1, o2);
-			Assert.AreEqual(-2, result);
+			Assert.IsNull(result);
 		}
 
 		[TestMethod]


### PR DESCRIPTION
Fixed two lookup function issues. First the arguments needed to be treated as RangeInfos since we set the LookupArgumentIndicies so that they resolve as ranges. Second, when matching values, it needed to ignore values of incompatible types. 